### PR TITLE
Backwards Compatibilty for lineman-blog

### DIFF
--- a/tasks/markdown.coffee
+++ b/tasks/markdown.coffee
@@ -43,7 +43,6 @@ module.exports = (grunt) ->
         index: "index.html"
         archive: "archive.html"
         rss: "index.xml"
-        root: "."
       dest: "dist"
       context:
         js: "app.js"


### PR DESCRIPTION
I've added some code to be backwords compatible with lineman-blog and anyone else using grunt-markdown-blog, which I probably should have done in the first place.

Will update lineman-blog with the changes to the grunt config but will probably have to add some sort of cwd option so the directory is rooted correctly. 
