### PR TITLE
Support \r\n newline character

### DIFF
--- a/lib/markdown_splitter.coffee
+++ b/lib/markdown_splitter.coffee
@@ -7,7 +7,7 @@ module.exports = class MarkdownSplitter
     inHeader = false
     header = []
     markdown = []
-    source.split("\n").forEach (line) ->
+    source.replace("\r\n", "\n").split("\n").forEach (line) ->
       if line == "---"
         inHeader = !inHeader
         return


### PR DESCRIPTION
I was having trouble using this as my editor (Notepad++) was inserting \r\n as the newline character and the markdown splitter was including my headers in post content.
