### PR TITLE
On Windows, there were problems with lines not being split correctly

### DIFF
--- a/lib/markdown_splitter.coffee
+++ b/lib/markdown_splitter.coffee
@@ -8,6 +8,7 @@ module.exports = class MarkdownSplitter
     header = []
     markdown = []
     source.replace("\r\n", "\n").split("\n").forEach (line) ->
+      line = line.replace(/\s*$/gm,'')
       if line == "---"
         inHeader = !inHeader
         return


### PR DESCRIPTION
On Windows, the below comparison (if line == "---") did not trigger, because there were some line endings left in the string. I trimmed These remaining trailing whitespaces away. 
