### PR TITLE
Fix front matter separator detection on Windows

### DIFF
--- a/lib/markdown_splitter.coffee
+++ b/lib/markdown_splitter.coffee
@@ -8,7 +8,7 @@ module.exports = class MarkdownSplitter
     header = []
     markdown = []
     source.replace("\r\n", "\n").split("\n").forEach (line) ->
-      if line == "---"
+      if line.trim() == "---"
         inHeader = !inHeader
         return
 


### PR DESCRIPTION
FIX: When running on Windows, there could be trailing whitespace which makes the == "---" fail
