### PR TITLE
deprecate Page#markdown

### DIFF
--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -7,7 +7,7 @@ module.exports = class Page
   constructor: (@path, @htmlDirPath, @dateFormat) ->
     @_markdown = new Markdown(grunt.file.read(@path))
     @attributes = @_markdown.header
-    @markdown = @_markdown.source #back-compat
+    deprecateMarkdownProperty(@)
 
   content: ->
     @_markdown.compile()
@@ -33,3 +33,9 @@ module.exports = class Page
 
   date: ->
     undefined
+
+deprecateMarkdownProperty = (page) ->
+  Object.defineProperty page, 'markdown',
+    get: ->
+      grunt.log.error("Page#markdown has been deprecated")
+      @_markdown.source

--- a/spec/helpers/spies.coffee
+++ b/spec/helpers/spies.coffee
@@ -3,3 +3,11 @@ jasmine.constructSpy = (classNameToFake, methodsToSpy = []) ->
   methodsToSpy.forEach (methodName) ->
     spies::[methodName] = jasmine.createSpy("#{classNameToFake}##{methodName}")
   spies
+
+jasmine.Matchers.ArgThat::jasmineToString = ->
+  "<jasmine.argThat(#{@matcher})>"
+
+jasmine.argThatMatches = (expected) ->
+  matcher = jasmine.argThat (actual) -> new RegExp(expected).test(actual)
+  matcher.jasmineToString = -> "<jasmine.argThatMatches: #{expected}>"
+  matcher

--- a/spec/page_spec.coffee
+++ b/spec/page_spec.coffee
@@ -1,30 +1,32 @@
-Page = null
 SandboxedModule = require('sandboxed-module')
+{ Page, grunt, Markdown } = {}
 
 describe "Page", ->
   Given -> Page = SandboxedModule.require '../lib/page',
     requires:
-      'grunt': @grunt = file: read: jasmine.createSpy('grunt.file.read')
-      './markdown': @markdown = jasmine.constructSpy('Markdown', ['compile'])
+      'grunt': grunt =
+        file: read: jasmine.createSpy('grunt.file.read')
+        log: error: jasmine.createSpy('grunt.log.error')
+      './markdown': Markdown = jasmine.constructSpy('Markdown', ['compile'])
 
   describe "#constructor", ->
     Given -> @path = "path"
-    Given -> @grunt.file.read.andReturn(@source = "source")
-    Given -> @markdown::header = @header = "attributes"
+    Given -> grunt.file.read.andReturn(@source = "source")
+    Given -> Markdown::header = @header = "attributes"
 
     When -> @subject = new Page(@path)
 
-    Then -> expect(@grunt.file.read).toHaveBeenCalledWith(@path)
-    Then -> expect(@markdown).toHaveBeenCalledWith(@source)
+    Then -> expect(grunt.file.read).toHaveBeenCalledWith(@path)
+    Then -> expect(Markdown).toHaveBeenCalledWith(@source)
     Then -> @subject.attributes == @header
 
   describe "#content", ->
     Given -> @subject = new Page()
-    Given -> @markdown::compile.andReturn(@parsedMarkdown = "content")
+    Given -> Markdown::compile.andReturn(@parsedMarkdown = "content")
 
     When -> @content = @subject.content()
 
-    Then -> expect(@markdown::compile).toHaveBeenCalled()
+    Then -> expect(Markdown::compile).toHaveBeenCalled()
     Then -> @content == @parsedMarkdown
 
   describe "#get", ->
@@ -90,3 +92,10 @@ describe "Page", ->
   describe "#date", ->
     Given -> @subject = new Page()
     Then -> @subject.date() == undefined
+
+  describe "#markdown", ->
+    Given -> @subject = new Page()
+    Given -> Markdown::source = @mdSource = "mdSource"
+    When -> @md = @subject.markdown
+    Then -> @md == @mdSource
+    Then -> expect(grunt.log.error).toHaveBeenCalledWith(jasmine.argThatMatches(/markdown.*deprecated/))


### PR DESCRIPTION
Page#markdown used to be a reference to the markdown source of the page.
There should be need for a page object to access its own original
markdown source. For the time being, it is delegated to _markdown.source

Presently, only emitting a logging error (does not stop the build or
require --force)

Next step: promote from logging error to grunt.fail.warn (which requires
--force)

Finally: remove the deprecated accessor altogether
