### PR TITLE
Deprecate old paths.markdown config option

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -21,6 +21,8 @@ module.exports = class Config
     src: ensureCompactArray(@raw.paths.pages)
 
   forPosts: ->
+    if @raw.paths.markdown?
+      log.error("Warning: config.paths.markdown is deprecated in favor of config.paths.posts")
     src = @raw.paths.markdown || @raw.paths.posts
     htmlDir: @raw.pathRoots.posts
     layoutPath: @raw.layouts.post

--- a/spec/config_spec.coffee
+++ b/spec/config_spec.coffee
@@ -76,3 +76,13 @@ describe "Config", ->
         @dateFormat
         src: ["a", "b"]
       }
+
+    context "with deprecated option (.markdown)", ->
+      Given -> @raw.paths.markdown = @path = "some/path/**/*"
+      Then -> expect(grunt.log.error).toHaveBeenCalled()
+      Then -> expect(@postsConfig).toEqual {
+        @htmlDir
+        @layoutPath
+        @dateFormat
+        src: [@path]
+      }


### PR DESCRIPTION
The old configuration option `paths.markdown` has been avoided for a
while (ever since a9220de83ed1fc3b75012e04ce0e787c5c107f3a)

Deprecation warning emitted as a grunt error, but does not stop the
build (or require --force)

Next step is to promote to grunt.fail.warn and finally remove it
altogether.
