### PR TITLE
Upgrade highlight.js to version 8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.8.0",
-    "highlight.js": "~7.3.0",
+    "highlight.js": "~8.3.0",
     "marked": "~0.2.8",
     "moment": "~2.8.3",
     "rss": "~1.0.0",


### PR DESCRIPTION
Version 8.3 comes with new themes and support for newer languages like Swift. It is a breaking change however, since new classes are used in the CSS.