### PR TITLE
upgrade dependencies, start to refactor and account for newer coffee-script compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "4"
-before_install: npm i -g grunt-cli@1.3.2
-script: grunt

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -2,7 +2,6 @@
 
 module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-jasmine-bundle'
-  grunt.loadNpmTasks 'grunt-release'
 
   grunt.initConfig
     spec:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # grunt-markdown-blog
 
+[![Node.js CI](https://github.com/testdouble/grunt-markdown-blog/actions/workflows/node.js.yml/badge.svg?branch=main)](https://github.com/testdouble/grunt-markdown-blog/actions/workflows/node.js.yml)
+
 This is a grunt multi-task for generating static blogs from posts written in markdown. It was designed to be used with [Lineman](https://github.com/testdouble/lineman), but should be generally useful to someone trying to accomplish the same.
 
-Here's an easy-to-clone repo that uses it: [testdouble/lineman-blog](https://github.com/testdouble/lineman-blog)
+Here's an easy-to-clone repo that uses it: [linemanjs/lineman-blog-template](https://github.com/linemanjs/lineman-blog-template)
 
 # Features
 
@@ -92,5 +94,3 @@ watch:
     files: ["app/posts/*.md", "app/pages/**/*.md", "app/templates/*.pug"]
     tasks: ["markdown:dev"]
 ```
-
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/testdouble/grunt-markdown-blog?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -53,7 +53,7 @@ module.exports = class Config
     src: ensureCompactArray(@raw.paths.pages)
 
   forPosts: ->
-    src = @raw.paths.markdown || @raw.paths.posts
+    src = @raw.paths.posts
     htmlDir: @raw.pathRoots.posts
     layoutPath: @raw.layouts.post
     dateFormat: @raw.dateFormat

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -1,11 +1,11 @@
-Layout = require('./layout')
-Feed = require('./feed')
+Archive  = require('./archive')
+Feed     = require('./feed')
+Index    = require('./index')
+Layout   = require('./layout')
 NullFeed = require('./null_feed')
-Archive = require('./archive')
-Index = require('./index')
 NullHtml = require('./null_html')
-Pages = require('./pages')
-Posts = require('./posts')
+Pages    = require('./pages')
+Posts    = require('./posts')
 
 module.exports = (grunt) ->
   archiveFrom: ({htmlPath, layoutPath}) ->

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -1,13 +1,4 @@
-Archive  = require('./archive')
-Feed     = require('./feed')
-Index    = require('./index')
-Layout   = require('./layout')
-NullFeed = require('./null_feed')
-NullHtml = require('./null_html')
-Pages    = require('./pages')
-Posts    = require('./posts')
-
-module.exports = (grunt) ->
+module.exports = (grunt, { Archive, Feed, Index, Layout, NullFeed, NullHtml, Pages, Posts }) ->
   archiveFrom: ({htmlPath, layoutPath}) ->
     unless htmlPath?
       grunt.log.writeln "Archive skipped: destination path undefined"

--- a/lib/generates_html.coffee
+++ b/lib/generates_html.coffee
@@ -1,7 +1,7 @@
 module.exports = class GeneratesHtml
   constructor: (@site, @wrapper) ->
 
-  generate: (template, post) ->
-    context = site: @site, post: post
+  generate: (template, postOrPage) ->
+    context = site: @site, post: postOrPage, page: postOrPage
     context.yield = template.htmlFor(context)
     @wrapper.htmlFor(context)

--- a/lib/generates_rss.coffee
+++ b/lib/generates_rss.coffee
@@ -1,6 +1,5 @@
 module.exports = class GeneratesRss
-  constructor: (@site) ->
-    @Rss = require('rss')
+  constructor: (@site, @Rss = require('rss')) ->
 
   generate: ->
     feed = @createFeed()

--- a/lib/generates_rss.coffee
+++ b/lib/generates_rss.coffee
@@ -16,7 +16,7 @@ module.exports = class GeneratesRss
 
   addPostsTo: (feed) ->
     if @site.rssCount > 0
-      @site.posts.slice(-@site.rssCount).reverse().forEach (post) =>
+      @site.getPosts().slice(-@site.rssCount).reverse().forEach (post) =>
         feed.item
           title: post.title()
           description: post.content()

--- a/lib/layout.coffee
+++ b/lib/layout.coffee
@@ -1,7 +1,6 @@
 _ = require('underscore')
 _.mixin(require('underscore.string').exports())
 pug = require('pug')
-grunt = require('grunt')
 
 module.exports = class Layout
   constructor: (@layoutPath, context = {}) ->

--- a/lib/markdown.coffee
+++ b/lib/markdown.coffee
@@ -1,18 +1,19 @@
-highlight = require('highlight.js')
+highlighter = require('highlight.js')
 marked = require('marked')
 MarkdownSplitter = require('./markdown_splitter')
 
-options =
-  highlight: (code, lang) ->
-    highlighted = if highlight.listLanguages()[lang]?
-      highlight.highlight(lang, code, true)
-    else
-      highlight.highlightAuto(code)
-    highlighted.value
-
 module.exports = class Markdown
-  constructor: (fullSource) ->
-    {@header, markdown: @source} = new MarkdownSplitter().split(fullSource)
+  constructor: (fullSource, compiler = marked, splitter = MarkdownSplitter) ->
+    @compiler = compiler
+    @splitter = new splitter()
+    {@header, markdown: @source} = @splitter.split(fullSource)
 
   compile: ->
-    marked(@source, options)
+    @compiler(@source, {
+      highlight: (code, lang) ->
+        highlighted = if highlighter.listLanguages()[lang]?
+          highlighter.highlight(lang, code, true)
+        else
+          highlighter.highlightAuto(code)
+        highlighted.value
+    })

--- a/lib/markdown_splitter.coffee
+++ b/lib/markdown_splitter.coffee
@@ -1,7 +1,7 @@
-coffeeScript = require('coffee-script')
-grunt = require('grunt')
+coffeeScript = require('coffeescript')
 
 module.exports = class MarkdownSplitter
+  constructor: (@logger = require('grunt')) ->
 
   split: (source = "") ->
     inHeader = false
@@ -43,5 +43,5 @@ module.exports = class MarkdownSplitter
                   #{source}
                   ---
                   """
-        grunt.warn(message)
+        @logger.warn(message)
         throw message

--- a/lib/markdown_task.coffee
+++ b/lib/markdown_task.coffee
@@ -4,9 +4,18 @@ GeneratesRss = require('../lib/generates_rss')
 Site = require('../lib/site')
 WritesFile = require('../lib/writes_file')
 
+Archive  = require('../lib/archive')
+Feed     = require('../lib/feed')
+Index    = require('../lib/index')
+Layout   = require('../lib/layout')
+NullFeed = require('../lib/null_feed')
+NullHtml = require('../lib/null_html')
+Pages    = require('../lib/pages')
+Posts    = require('../lib/posts')
+
 module.exports = class MarkdownTask
   constructor: (grunt, @config) ->
-    factory = Factory(grunt)
+    factory = Factory(grunt, { Archive, Feed, Index, Layout, NullFeed, NullHtml, Pages, Posts })
     @posts = factory.postsFrom @config.forPosts()
     @pages = factory.pagesFrom @config.forPages()
     @index = factory.indexFrom @posts.newest(), @config.forIndex()

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -5,12 +5,11 @@ Path = require('./path')
 
 module.exports = class Page
   constructor: (@path, @htmlDirPath, @dateFormat, @reader = grunt.file) ->
-    @_markdown = new Markdown(@reader.read(@path))
-    @attributes = @_markdown.header
-    @markdown = @_markdown.source #back-compat
+    @markdown = new Markdown(@reader.read(@path))
+    @attributes = @markdown.header
 
   content: ->
-    @_markdown.compile()
+    @markdown.compile()
 
   get: (name) ->
     _(@attributes).result(name)

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -4,8 +4,8 @@ Markdown = require('./markdown')
 Path = require('./path')
 
 module.exports = class Page
-  constructor: (@path, @htmlDirPath, @dateFormat) ->
-    @_markdown = new Markdown(grunt.file.read(@path))
+  constructor: (@path, @htmlDirPath, @dateFormat, @reader = grunt.file) ->
+    @_markdown = new Markdown(@reader.read(@path))
     @attributes = @_markdown.header
     @markdown = @_markdown.source #back-compat
 

--- a/lib/pages.coffee
+++ b/lib/pages.coffee
@@ -7,9 +7,7 @@ module.exports = class Pages
     @pages = pages
 
   htmlFor: (site, page) ->
-    # knowingly set as 'post' for backcompat
-    # TODO: deprecate page-as-post in context object
-    @pages.layout.htmlFor {site, post: page}
+    @pages.layout.htmlFor {site, page}
 
   writeHtml: (generatesHtml, writesFile) ->
     for page in @pages

--- a/lib/pages.coffee
+++ b/lib/pages.coffee
@@ -1,19 +1,17 @@
 Page = require './page'
 
 module.exports = class Pages
-  @:: = new Array
   constructor: (markdownFiles, {htmlDir, layout}) ->
     pages = markdownFiles.map (file) -> new Page(file, htmlDir)
-    pages.__proto__ = Pages::
     pages.layout = layout
-    return pages
+    @pages = pages
 
   htmlFor: (site, page) ->
     # knowingly set as 'post' for backcompat
     # TODO: deprecate page-as-post in context object
-    @layout.htmlFor {site, post: page}
+    @pages.layout.htmlFor {site, post: page}
 
   writeHtml: (generatesHtml, writesFile) ->
-    for page in @
-      html = generatesHtml.generate(@layout, page)
+    for page in @pages
+      html = generatesHtml.generate(@pages.layout, page)
       writesFile.write(html, page.htmlPath())

--- a/lib/post.coffee
+++ b/lib/post.coffee
@@ -1,5 +1,5 @@
 moment = require('moment')
-Page = require("./../lib/page")
+Page = require("./page")
 
 module.exports = class Post extends Page
   date: ->

--- a/lib/posts.coffee
+++ b/lib/posts.coffee
@@ -4,31 +4,28 @@ module.exports = class Posts
   timeComparator = (post1, post2) ->
     post1.time().localeCompare(post2.time(), numeric: true)
 
-  @:: = new Array
   constructor: (markdownFiles, {htmlDir, layout, dateFormat, comparator}) ->
     posts = markdownFiles.map (file) -> new Post(file, htmlDir, dateFormat)
-    posts.layout = layout
     posts.sort(comparator || timeComparator)
-    posts.__proto__ = Posts::
     posts.layout = layout
-    return posts
+    @posts = posts
 
   oldest: ->
-    @[0]
+    @posts[0]
 
   newest: ->
-    @[@length - 1]
+    @posts[@posts.length - 1]
 
   htmlFor: (site, post) ->
-    @layout.htmlFor {site, post}
+    @posts.layout.htmlFor {site, post}
 
   writeHtml: (generatesHtml, writesFile) ->
-    for post in @
-      html = generatesHtml.generate(@layout, post)
+    for post in @posts
+      html = generatesHtml.generate(@posts.layout, post)
       writesFile.write(html, post.htmlPath())
 
   older: (post) ->
-    @[@indexOf(post) - 1] unless post is @oldest
+    @posts[@posts.indexOf(post) - 1] unless post is @oldest
 
   newer: (post) ->
-    @[@indexOf(post) + 1] unless post is @newest
+    @posts[@posts.indexOf(post) + 1] unless post is @newest

--- a/lib/posts.coffee
+++ b/lib/posts.coffee
@@ -1,14 +1,14 @@
 Post = require './post'
 
 module.exports = class Posts
-  timeComparator = (post1, post2) ->
-    post1.time().localeCompare(post2.time(), numeric: true)
-
   constructor: (markdownFiles, {htmlDir, layout, dateFormat, comparator}) ->
     posts = markdownFiles.map (file) -> new Post(file, htmlDir, dateFormat)
     posts.sort(comparator || timeComparator)
     posts.layout = layout
     @posts = posts
+
+  timeComparator = (post1, post2) ->
+    post1.time().localeCompare(post2.time(), numeric: true)
 
   oldest: ->
     @posts[0]

--- a/lib/site.coffee
+++ b/lib/site.coffee
@@ -15,3 +15,29 @@ module.exports = class Site
 
   urlFor: (post) ->
     "#{@url}/#{post.htmlPath()}"
+
+  getPosts: ->
+    @posts.posts
+
+    # previously, site.posts was an instance of the Posts class
+    # which depended on some coffeescript 1.x + es5 prototype
+    # cleverness to inherit properties from the native Array class
+
+    # class Posts
+    #  @:: = new Array
+    #  constructor: () ->
+    #    posts.__proto__ = Posts::
+
+    # we can't really do this in es6 classes so I created
+    # this accessor so that upstream users don't need to
+    # double reference site.posts.posts in their pug templates
+
+    # the only place this behaviour was used in upstream packages
+    # was in blogs that had used lineman-blog-template to scaffold
+    # their repos
+    # - https://github.com/linemanjs/lineman-blog-template/blob/f3c996fc8b8ff1d22b2dca2825e040741528ad4d/app/templates/archive.us#L5
+    # - https://github.com/linemanjs/lineman-blog-template/blob/f3c996fc8b8ff1d22b2dca2825e040741528ad4d/app/templates/index.us#L1
+
+    # the only other place within this codebase that depended
+    # on this behaviour was lib/generates_rss.coffee
+    # - https://github.com/testdouble/grunt-markdown-blog/blob/cdee500123face4bb9c897a51af682c9e5df5118/lib/generates_rss.coffee#L21

--- a/lib/site.coffee
+++ b/lib/site.coffee
@@ -19,25 +19,5 @@ module.exports = class Site
   getPosts: ->
     @posts.posts
 
-    # previously, site.posts was an instance of the Posts class
-    # which depended on some coffeescript 1.x + es5 prototype
-    # cleverness to inherit properties from the native Array class
-
-    # class Posts
-    #  @:: = new Array
-    #  constructor: () ->
-    #    posts.__proto__ = Posts::
-
-    # we can't really do this in es6 classes so I created
-    # this accessor so that upstream users don't need to
-    # double reference site.posts.posts in their pug templates
-
-    # the only place this behaviour was used in upstream packages
-    # was in blogs that had used lineman-blog-template to scaffold
-    # their repos
-    # - https://github.com/linemanjs/lineman-blog-template/blob/f3c996fc8b8ff1d22b2dca2825e040741528ad4d/app/templates/archive.us#L5
-    # - https://github.com/linemanjs/lineman-blog-template/blob/f3c996fc8b8ff1d22b2dca2825e040741528ad4d/app/templates/index.us#L1
-
-    # the only other place within this codebase that depended
-    # on this behaviour was lib/generates_rss.coffee
-    # - https://github.com/testdouble/grunt-markdown-blog/blob/cdee500123face4bb9c897a51af682c9e5df5118/lib/generates_rss.coffee#L21
+  getPages: ->
+    @pages.pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
         "coffeescript": "^2.5.1",
         "grunt": "^1.4.0",
         "highlight.js": "^10.7.2",
-        "marked": "^0.3.6",
+        "marked": "^2.0.3",
         "moment": "~2.8.3",
-        "pug": "^2.0.0-beta6",
-        "rss": "~1.0.0",
+        "pug": "^3.0.2",
+        "rss": "^1.2.2",
         "underscore": "~1.7.0",
         "underscore.string": "~2.3.3"
       },
@@ -23,17 +23,29 @@
         "testdouble": "^3.16.1"
       }
     },
-    "node_modules/@types/babel-types": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
-      "integrity": "sha512-qZLoYeXSTgQuK1h7QQS16hqLGdmqtRmN8w/rl3Au/l5x/zkHx+a4VHrHyBsi1I1vtK2oBHxSzKIu0R5p6spdOA=="
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
     },
-    "node_modules/@types/babylon": {
-      "version": "6.16.5",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
-      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+    "node_modules/@babel/parser": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
+      "integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
       "dependencies": {
-        "@types/babel-types": "*"
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/abbrev": {
@@ -42,35 +54,14 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "dependencies": {
-        "acorn": "^4.0.4"
-      }
-    },
-    "node_modules/align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dependencies": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -116,42 +107,25 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "node_modules/assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
+    },
     "node_modules/async": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+    "node_modules/babel-walk": {
+      "version": "3.0.0-canary-5",
+      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
       "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "node_modules/babel-types/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "bin": {
-        "babylon": "bin/babylon.js"
+        "@babel/types": "^7.9.6"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -191,26 +165,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dependencies": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
@@ -232,27 +186,6 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "dependencies": {
         "is-regex": "^1.0.3"
-      }
-    },
-    "node_modules/clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dependencies": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
       }
     },
     "node_modules/coffeescript": {
@@ -297,22 +230,13 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/constantinople": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
-      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
+      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
       "dependencies": {
-        "@types/babel-types": "^7.0.0",
-        "@types/babylon": "^6.16.2",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0"
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.1"
       }
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
     },
     "node_modules/dateformat": {
       "version": "3.0.3",
@@ -320,14 +244,6 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/detect-file": {
@@ -353,14 +269,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter2": {
@@ -841,11 +749,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-core-module": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
@@ -858,12 +761,12 @@
       }
     },
     "node_modules/is-expression": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
       "dependencies": {
-        "acorn": "~4.0.2",
-        "object-assign": "^4.0.1"
+        "acorn": "^7.1.1",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/is-extglob": {
@@ -1088,25 +991,6 @@
         "promise": "^7.0.1"
       }
     },
-    "node_modules/kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dependencies": {
-        "is-buffer": "^1.1.5"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/liftup": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/liftup/-/liftup-3.0.1.tgz",
@@ -1149,14 +1033,6 @@
         "rhino"
       ]
     },
-    "node_modules/longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -1185,14 +1061,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 8.16.2"
       }
     },
     "node_modules/micromatch": {
@@ -1207,15 +1083,23 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "bin": {
-        "mime": "cli.js"
+    "node_modules/mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+      "dependencies": {
+        "mime-db": "~1.25.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.6"
       }
     },
     "node_modules/minijasminenode": {
@@ -1419,118 +1303,116 @@
       }
     },
     "node_modules/pug": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
-      "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
+      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
       "dependencies": {
-        "pug-code-gen": "^2.0.2",
-        "pug-filters": "^3.1.1",
-        "pug-lexer": "^4.1.0",
-        "pug-linker": "^3.0.6",
-        "pug-load": "^2.0.12",
-        "pug-parser": "^5.0.1",
-        "pug-runtime": "^2.0.5",
-        "pug-strip-comments": "^1.0.4"
+        "pug-code-gen": "^3.0.2",
+        "pug-filters": "^4.0.0",
+        "pug-lexer": "^5.0.1",
+        "pug-linker": "^4.0.0",
+        "pug-load": "^3.0.0",
+        "pug-parser": "^6.0.0",
+        "pug-runtime": "^3.0.1",
+        "pug-strip-comments": "^2.0.0"
       }
     },
     "node_modules/pug-attrs": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
-      "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
       "dependencies": {
-        "constantinople": "^3.0.1",
-        "js-stringify": "^1.0.1",
-        "pug-runtime": "^2.0.5"
+        "constantinople": "^4.0.1",
+        "js-stringify": "^1.0.2",
+        "pug-runtime": "^3.0.0"
       }
     },
     "node_modules/pug-code-gen": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.3.tgz",
-      "integrity": "sha512-r9sezXdDuZJfW9J91TN/2LFbiqDhmltTFmGpHTsGdrNGp3p4SxAjjXEfnuK2e4ywYsRIVP0NeLbSAMHUcaX1EA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
+      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
       "dependencies": {
-        "constantinople": "^3.1.2",
+        "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
-        "js-stringify": "^1.0.1",
-        "pug-attrs": "^2.0.4",
-        "pug-error": "^1.3.3",
-        "pug-runtime": "^2.0.5",
-        "void-elements": "^2.0.1",
-        "with": "^5.0.0"
+        "js-stringify": "^1.0.2",
+        "pug-attrs": "^3.0.0",
+        "pug-error": "^2.0.0",
+        "pug-runtime": "^3.0.0",
+        "void-elements": "^3.1.0",
+        "with": "^7.0.0"
       }
     },
     "node_modules/pug-error": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
-      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
     },
     "node_modules/pug-filters": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
-      "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
+      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
       "dependencies": {
-        "clean-css": "^4.1.11",
-        "constantinople": "^3.0.1",
+        "constantinople": "^4.0.1",
         "jstransformer": "1.0.0",
-        "pug-error": "^1.3.3",
-        "pug-walk": "^1.1.8",
-        "resolve": "^1.1.6",
-        "uglify-js": "^2.6.1"
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0",
+        "resolve": "^1.15.1"
       }
     },
     "node_modules/pug-lexer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
-      "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
       "dependencies": {
-        "character-parser": "^2.1.1",
-        "is-expression": "^3.0.0",
-        "pug-error": "^1.3.3"
+        "character-parser": "^2.2.0",
+        "is-expression": "^4.0.0",
+        "pug-error": "^2.0.0"
       }
     },
     "node_modules/pug-linker": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
-      "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
+      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
       "dependencies": {
-        "pug-error": "^1.3.3",
-        "pug-walk": "^1.1.8"
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0"
       }
     },
     "node_modules/pug-load": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
-      "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
+      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
       "dependencies": {
-        "object-assign": "^4.1.0",
-        "pug-walk": "^1.1.8"
+        "object-assign": "^4.1.1",
+        "pug-walk": "^2.0.0"
       }
     },
     "node_modules/pug-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
-      "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
       "dependencies": {
-        "pug-error": "^1.3.3",
-        "token-stream": "0.0.1"
+        "pug-error": "^2.0.0",
+        "token-stream": "1.0.0"
       }
     },
     "node_modules/pug-runtime": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
-      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg=="
     },
     "node_modules/pug-strip-comments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
-      "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
       "dependencies": {
-        "pug-error": "^1.3.3"
+        "pug-error": "^2.0.0"
       }
     },
     "node_modules/pug-walk": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
-      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
+      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
     },
     "node_modules/quibble": {
       "version": "0.6.5",
@@ -1563,19 +1445,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -1600,17 +1469,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dependencies": {
-        "align-text": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1626,26 +1484,18 @@
       }
     },
     "node_modules/rss": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rss/-/rss-1.0.1.tgz",
-      "integrity": "sha1-63KokwsioOVeKo5qPVl2KF4Sfq0=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
       "dependencies": {
-        "mime": "^1.2.11",
-        "xml": "^1.0.0"
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
       }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -1704,11 +1554,11 @@
       "dev": true
     },
     "node_modules/to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -1723,41 +1573,9 @@
       }
     },
     "node_modules/token-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
-    },
-    "node_modules/uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dependencies": {
-        "source-map": "~0.5.1",
-        "yargs": "~3.10.0"
-      },
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      },
-      "optionalDependencies": {
-        "uglify-to-browserify": "~1.0.0"
-      }
-    },
-    "node_modules/uglify-js/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+      "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ="
     },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
@@ -1797,9 +1615,9 @@
       }
     },
     "node_modules/void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1818,40 +1636,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/with": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
       "dependencies": {
-        "acorn": "^3.1.0",
-        "acorn-globals": "^3.0.0"
-      }
-    },
-    "node_modules/with/node_modules/acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-      "bin": {
-        "acorn": "bin/acorn"
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
+        "assert-never": "^1.2.1",
+        "babel-walk": "3.0.0-canary-5"
       },
       "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-      "engines": {
-        "node": ">=0.4.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/wrappy": {
@@ -1863,31 +1659,26 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
-    },
-    "node_modules/yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dependencies": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     }
   },
   "dependencies": {
-    "@types/babel-types": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
-      "integrity": "sha512-qZLoYeXSTgQuK1h7QQS16hqLGdmqtRmN8w/rl3Au/l5x/zkHx+a4VHrHyBsi1I1vtK2oBHxSzKIu0R5p6spdOA=="
+    "@babel/helper-validator-identifier": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
     },
-    "@types/babylon": {
-      "version": "6.16.5",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
-      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+    "@babel/parser": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
+      "integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q=="
+    },
+    "@babel/types": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
       "requires": {
-        "@types/babel-types": "*"
+        "@babel/helper-validator-identifier": "^7.14.0",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "abbrev": {
@@ -1896,27 +1687,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-    },
-    "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "requires": {
-        "acorn": "^4.0.4"
-      }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -1949,42 +1722,23 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
+    },
     "async": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+    "babel-walk": {
+      "version": "3.0.0-canary-5",
+      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "@babel/types": "^7.9.6"
       }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        }
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -2017,20 +1771,6 @@
         "get-intrinsic": "^1.0.2"
       }
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
-    },
     "chalk": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
@@ -2046,24 +1786,6 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "requires": {
         "is-regex": "^1.0.3"
-      }
-    },
-    "clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
-      "requires": {
-        "source-map": "~0.6.0"
-      }
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
       }
     },
     "coffeescript": {
@@ -2095,30 +1817,18 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "constantinople": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
-      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
+      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
       "requires": {
-        "@types/babel-types": "^7.0.0",
-        "@types/babylon": "^6.16.2",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0"
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.1"
       }
-    },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -2134,11 +1844,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -2513,11 +2218,6 @@
         "is-windows": "^1.0.1"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "is-core-module": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
@@ -2527,12 +2227,12 @@
       }
     },
     "is-expression": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
-      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
       "requires": {
-        "acorn": "~4.0.2",
-        "object-assign": "^4.0.1"
+        "acorn": "^7.1.1",
+        "object-assign": "^4.1.1"
       }
     },
     "is-extglob": {
@@ -2700,19 +2400,6 @@
         "promise": "^7.0.1"
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
     "liftup": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/liftup/-/liftup-3.0.1.tgz",
@@ -2747,11 +2434,6 @@
       "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
       "dev": true
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -2773,9 +2455,9 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+      "integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA=="
     },
     "micromatch": {
       "version": "4.0.4",
@@ -2786,10 +2468,18 @@
         "picomatch": "^2.2.3"
       }
     },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    "mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+    },
+    "mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+      "requires": {
+        "mime-db": "~1.25.0"
+      }
     },
     "minijasminenode": {
       "version": "0.2.7",
@@ -2935,118 +2625,116 @@
       }
     },
     "pug": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
-      "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
+      "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
       "requires": {
-        "pug-code-gen": "^2.0.2",
-        "pug-filters": "^3.1.1",
-        "pug-lexer": "^4.1.0",
-        "pug-linker": "^3.0.6",
-        "pug-load": "^2.0.12",
-        "pug-parser": "^5.0.1",
-        "pug-runtime": "^2.0.5",
-        "pug-strip-comments": "^1.0.4"
+        "pug-code-gen": "^3.0.2",
+        "pug-filters": "^4.0.0",
+        "pug-lexer": "^5.0.1",
+        "pug-linker": "^4.0.0",
+        "pug-load": "^3.0.0",
+        "pug-parser": "^6.0.0",
+        "pug-runtime": "^3.0.1",
+        "pug-strip-comments": "^2.0.0"
       }
     },
     "pug-attrs": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
-      "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
       "requires": {
-        "constantinople": "^3.0.1",
-        "js-stringify": "^1.0.1",
-        "pug-runtime": "^2.0.5"
+        "constantinople": "^4.0.1",
+        "js-stringify": "^1.0.2",
+        "pug-runtime": "^3.0.0"
       }
     },
     "pug-code-gen": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.3.tgz",
-      "integrity": "sha512-r9sezXdDuZJfW9J91TN/2LFbiqDhmltTFmGpHTsGdrNGp3p4SxAjjXEfnuK2e4ywYsRIVP0NeLbSAMHUcaX1EA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
+      "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
       "requires": {
-        "constantinople": "^3.1.2",
+        "constantinople": "^4.0.1",
         "doctypes": "^1.1.0",
-        "js-stringify": "^1.0.1",
-        "pug-attrs": "^2.0.4",
-        "pug-error": "^1.3.3",
-        "pug-runtime": "^2.0.5",
-        "void-elements": "^2.0.1",
-        "with": "^5.0.0"
+        "js-stringify": "^1.0.2",
+        "pug-attrs": "^3.0.0",
+        "pug-error": "^2.0.0",
+        "pug-runtime": "^3.0.0",
+        "void-elements": "^3.1.0",
+        "with": "^7.0.0"
       }
     },
     "pug-error": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
-      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
+      "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ=="
     },
     "pug-filters": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
-      "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
+      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
       "requires": {
-        "clean-css": "^4.1.11",
-        "constantinople": "^3.0.1",
+        "constantinople": "^4.0.1",
         "jstransformer": "1.0.0",
-        "pug-error": "^1.3.3",
-        "pug-walk": "^1.1.8",
-        "resolve": "^1.1.6",
-        "uglify-js": "^2.6.1"
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0",
+        "resolve": "^1.15.1"
       }
     },
     "pug-lexer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
-      "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
       "requires": {
-        "character-parser": "^2.1.1",
-        "is-expression": "^3.0.0",
-        "pug-error": "^1.3.3"
+        "character-parser": "^2.2.0",
+        "is-expression": "^4.0.0",
+        "pug-error": "^2.0.0"
       }
     },
     "pug-linker": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
-      "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
+      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
       "requires": {
-        "pug-error": "^1.3.3",
-        "pug-walk": "^1.1.8"
+        "pug-error": "^2.0.0",
+        "pug-walk": "^2.0.0"
       }
     },
     "pug-load": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
-      "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
+      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "pug-walk": "^1.1.8"
+        "object-assign": "^4.1.1",
+        "pug-walk": "^2.0.0"
       }
     },
     "pug-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
-      "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
       "requires": {
-        "pug-error": "^1.3.3",
-        "token-stream": "0.0.1"
+        "pug-error": "^2.0.0",
+        "token-stream": "1.0.0"
       }
     },
     "pug-runtime": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
-      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg=="
     },
     "pug-strip-comments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
-      "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
       "requires": {
-        "pug-error": "^1.3.3"
+        "pug-error": "^2.0.0"
       }
     },
     "pug-walk": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
-      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
+      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ=="
     },
     "quibble": {
       "version": "0.6.5",
@@ -3074,16 +2762,6 @@
         "resolve": "^1.9.0"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
     "resolve": {
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -3102,14 +2780,6 @@
         "global-modules": "^1.0.0"
       }
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "^0.1.1"
-      }
-    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -3119,23 +2789,18 @@
       }
     },
     "rss": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rss/-/rss-1.0.1.tgz",
-      "integrity": "sha1-63KokwsioOVeKo5qPVl2KF4Sfq0=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
       "requires": {
-        "mime": "^1.2.11",
-        "xml": "^1.0.0"
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
       }
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3187,9 +2852,9 @@
       "dev": true
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -3200,32 +2865,9 @@
       }
     },
     "token-stream": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+      "integrity": "sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ="
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -3256,9 +2898,9 @@
       }
     },
     "void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk="
     },
     "which": {
       "version": "2.0.2",
@@ -3268,31 +2910,16 @@
         "isexe": "^2.0.0"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
-    },
     "with": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
-      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
       "requires": {
-        "acorn": "^3.1.0",
-        "acorn-globals": "^3.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-        }
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
+        "assert-never": "^1.2.1",
+        "babel-walk": "3.0.0-canary-5"
       }
-    },
-    "wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -3303,17 +2930,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3319 @@
+{
+  "name": "grunt-markdown-blog",
+  "version": "1.2.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "coffeescript": "^2.5.1",
+        "grunt": "^1.4.0",
+        "highlight.js": "^10.7.2",
+        "marked": "^0.3.6",
+        "moment": "~2.8.3",
+        "pug": "^2.0.0-beta6",
+        "rss": "~1.0.0",
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.3.3"
+      },
+      "devDependencies": {
+        "grunt-jasmine-bundle": "^0.4.0",
+        "testdouble": "^3.16.1"
+      }
+    },
+    "node_modules/@types/babel-types": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
+      "integrity": "sha512-qZLoYeXSTgQuK1h7QQS16hqLGdmqtRmN8w/rl3Au/l5x/zkHx+a4VHrHyBsi1I1vtK2oBHxSzKIu0R5p6spdOA=="
+    },
+    "node_modules/@types/babylon": {
+      "version": "6.16.5",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
+      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+      "dependencies": {
+        "@types/babel-types": "*"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "node_modules/acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "dependencies": {
+        "acorn": "^4.0.4"
+      }
+    },
+    "node_modules/align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dependencies": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "node_modules/async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/babel-types/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "bin": {
+        "babylon": "bin/babylon.js"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dependencies": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
+      "dependencies": {
+        "is-regex": "^1.0.3"
+      }
+    },
+    "node_modules/clean-css": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dependencies": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "node_modules/coffeescript": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz",
+      "integrity": "sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ==",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/constantinople": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
+      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+      "dependencies": {
+        "@types/babel-types": "^7.0.0",
+        "@types/babylon": "^6.16.2",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true
+    },
+    "node_modules/dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/doctypes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dependencies": {
+        "glob": "~5.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/fined": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+      "dependencies": {
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/flagged-respawn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/getobject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-1.0.0.tgz",
+      "integrity": "sha512-tbUz6AKKKr2YiMB+fLWIgq5ZeBOobop9YMMAU9dC54/ot2ksMXt3DOFyBuhZw6ptcVszEykgByK20j7W9jHFag==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dependencies": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dependencies": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/grunt": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.0.tgz",
+      "integrity": "sha512-yRFc0GVCDu9yxqOFzpuXQ2pEdgtLDnFv5Qz54jfIcNnpJ8Z7B7P7kPkT4VMuRvm+N+QOsI8C4v/Q0DSaoj3LgQ==",
+      "dependencies": {
+        "dateformat": "~3.0.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.2",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.1.6",
+        "grunt-cli": "~1.4.2",
+        "grunt-known-options": "~1.1.1",
+        "grunt-legacy-log": "~3.0.0",
+        "grunt-legacy-util": "~2.0.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.14.0",
+        "minimatch": "~3.0.4",
+        "mkdirp": "~1.0.4",
+        "nopt": "~3.0.6",
+        "rimraf": "~3.0.2"
+      },
+      "bin": {
+        "grunt": "bin/grunt"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/grunt-cli": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.2.tgz",
+      "integrity": "sha512-wsu6BZh7KCnfeaSkDrKIAvOlqGKxNRTZjc8xfZlvxCByQIqUfZ31kh5uHpPnhQ4NdVgvaWaVxa1LUbVU80nACw==",
+      "dependencies": {
+        "grunt-known-options": "~1.1.1",
+        "interpret": "~1.1.0",
+        "liftup": "~3.0.1",
+        "nopt": "~4.0.1",
+        "v8flags": "~3.2.0"
+      },
+      "bin": {
+        "grunt": "bin/grunt"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/grunt-cli/node_modules/nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/grunt-jasmine-bundle": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-jasmine-bundle/-/grunt-jasmine-bundle-0.4.0.tgz",
+      "integrity": "sha1-mbLFbTBVHBeK2+b/5oWcUAu+UOg=",
+      "dev": true,
+      "dependencies": {
+        "coffee-script": "~1.6.3",
+        "jasmine-before-all": "~0.1.0",
+        "jasmine-given": "~2.5.0",
+        "jasmine-only": "~0.1.0",
+        "jasmine-stealth": "~0.0.13",
+        "lodash": "~0.9.0",
+        "minijasminenode": "~1.1.1"
+      },
+      "peerDependencies": {
+        "grunt": ">=0.4.1"
+      }
+    },
+    "node_modules/grunt-jasmine-bundle/node_modules/coffee-script": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/grunt-jasmine-bundle/node_modules/minijasminenode": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz",
+      "integrity": "sha1-f5Y31mQopTHAX08QtpoxG137YOk=",
+      "dev": true,
+      "bin": {
+        "minijasminenode": "bin/minijn"
+      }
+    },
+    "node_modules/grunt-known-options": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/grunt-legacy-log": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-3.0.0.tgz",
+      "integrity": "sha512-GHZQzZmhyq0u3hr7aHW4qUH0xDzwp2YXldLPZTCjlOeGscAOWWPftZG3XioW8MasGp+OBRIu39LFx14SLjXRcA==",
+      "dependencies": {
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.19"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.1.0.tgz",
+      "integrity": "sha512-lwquaPXJtKQk0rUM1IQAop5noEpwFqOXasVoedLeNzaibf/OPWjKYvvdqnEHNmU+0T0CaReAXIbGo747ZD+Aaw==",
+      "dependencies": {
+        "chalk": "~4.1.0",
+        "lodash": "~4.17.19"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/grunt-legacy-log/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/grunt-legacy-util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-2.0.1.tgz",
+      "integrity": "sha512-2bQiD4fzXqX8rhNdXkAywCadeqiPiay0oQny77wA2F3WF4grPJXCvAcyoWUJV+po/b15glGkxuSiQCK299UC2w==",
+      "dependencies": {
+        "async": "~3.2.0",
+        "exit": "~0.1.2",
+        "getobject": "~1.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.21",
+        "underscore.string": "~3.3.5",
+        "which": "~2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/grunt-legacy-util/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/grunt-legacy-util/node_modules/underscore.string": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "dependencies": {
+        "sprintf-js": "^1.0.3",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
+      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+    },
+    "node_modules/is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dependencies": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-expression": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
+      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
+      "dependencies": {
+        "acorn": "~4.0.2",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dependencies": {
+        "is-unc-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dependencies": {
+        "unc-path-regex": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jasmine-before-all": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/jasmine-before-all/-/jasmine-before-all-0.1.2.tgz",
+      "integrity": "sha1-H0UgQfWds2rFZTInw56NGbb8eZ8=",
+      "dev": true
+    },
+    "node_modules/jasmine-given": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jasmine-given/-/jasmine-given-2.5.1.tgz",
+      "integrity": "sha1-NyD8Jo753AHob65TI9+FKf/MaC4=",
+      "dev": true,
+      "dependencies": {
+        "coffee-script": "~ 1.6.3",
+        "minijasminenode": "~0.2.4"
+      }
+    },
+    "node_modules/jasmine-given/node_modules/coffee-script": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/jasmine-only": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/jasmine-only/-/jasmine-only-0.1.2.tgz",
+      "integrity": "sha1-kb27r5B8wCjRmVao46c8kUR4O+c=",
+      "dev": true,
+      "dependencies": {
+        "coffee-script": "~ 1.6.3"
+      }
+    },
+    "node_modules/jasmine-only/node_modules/coffee-script": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/jasmine-stealth": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/jasmine-stealth/-/jasmine-stealth-0.0.17.tgz",
+      "integrity": "sha1-ICp+rnKmwbdbtsCbxdNYrb9Ngnc=",
+      "dev": true,
+      "dependencies": {
+        "coffee-script": "~ 1.6.3",
+        "minijasminenode": "~0.2.4"
+      }
+    },
+    "node_modules/jasmine-stealth/node_modules/coffee-script": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+      "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/js-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jstransformer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
+      "dependencies": {
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/liftup": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/liftup/-/liftup-3.0.1.tgz",
+      "integrity": "sha512-yRHaiQDizWSzoXk3APcA71eOI/UuhEkNN9DiW2Tt44mhYzX4joFoCZlxsSOF7RyeLlfqzFLQI1ngFq3ggMPhOw==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "findup-sync": "^4.0.0",
+        "fined": "^1.2.0",
+        "flagged-respawn": "^1.0.1",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.1",
+        "rechoir": "^0.7.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/liftup/node_modules/findup-sync": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+      "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+      "dependencies": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^4.0.2",
+        "resolve-dir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true,
+      "engines": [
+        "node",
+        "rhino"
+      ]
+    },
+    "node_modules/longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/make-iterator/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minijasminenode": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-0.2.7.tgz",
+      "integrity": "sha1-U0/UVQGZrGjypw3IfGLarpOT5oE=",
+      "dev": true,
+      "bin": {
+        "minijasminenode": "bin/minijn"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+      "integrity": "sha1-zBdKq7GSI+//VpmpRngFoniYOL8=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "dependencies": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "dependencies": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "node_modules/parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dependencies": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "node_modules/path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dependencies": {
+        "path-root-regex": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/pug": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
+      "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
+      "dependencies": {
+        "pug-code-gen": "^2.0.2",
+        "pug-filters": "^3.1.1",
+        "pug-lexer": "^4.1.0",
+        "pug-linker": "^3.0.6",
+        "pug-load": "^2.0.12",
+        "pug-parser": "^5.0.1",
+        "pug-runtime": "^2.0.5",
+        "pug-strip-comments": "^1.0.4"
+      }
+    },
+    "node_modules/pug-attrs": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
+      "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
+      "dependencies": {
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.5"
+      }
+    },
+    "node_modules/pug-code-gen": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.3.tgz",
+      "integrity": "sha512-r9sezXdDuZJfW9J91TN/2LFbiqDhmltTFmGpHTsGdrNGp3p4SxAjjXEfnuK2e4ywYsRIVP0NeLbSAMHUcaX1EA==",
+      "dependencies": {
+        "constantinople": "^3.1.2",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.4",
+        "pug-error": "^1.3.3",
+        "pug-runtime": "^2.0.5",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
+      }
+    },
+    "node_modules/pug-error": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
+      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
+    },
+    "node_modules/pug-filters": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
+      "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
+      "dependencies": {
+        "clean-css": "^4.1.11",
+        "constantinople": "^3.0.1",
+        "jstransformer": "1.0.0",
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
+      }
+    },
+    "node_modules/pug-lexer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
+      "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
+      "dependencies": {
+        "character-parser": "^2.1.1",
+        "is-expression": "^3.0.0",
+        "pug-error": "^1.3.3"
+      }
+    },
+    "node_modules/pug-linker": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
+      "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
+      "dependencies": {
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8"
+      }
+    },
+    "node_modules/pug-load": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
+      "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "pug-walk": "^1.1.8"
+      }
+    },
+    "node_modules/pug-parser": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
+      "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
+      "dependencies": {
+        "pug-error": "^1.3.3",
+        "token-stream": "0.0.1"
+      }
+    },
+    "node_modules/pug-runtime": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
+      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
+    },
+    "node_modules/pug-strip-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
+      "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
+      "dependencies": {
+        "pug-error": "^1.3.3"
+      }
+    },
+    "node_modules/pug-walk": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
+      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
+    },
+    "node_modules/quibble": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.5.tgz",
+      "integrity": "sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14",
+        "resolve": "^1.11.1"
+      },
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/quibble/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/rechoir": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
+      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dependencies": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dependencies": {
+        "align-text": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rss": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.0.1.tgz",
+      "integrity": "sha1-63KokwsioOVeKo5qPVl2KF4Sfq0=",
+      "dependencies": {
+        "mime": "^1.2.11",
+        "xml": "^1.0.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "node_modules/stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha1-BXw8mpChJzObudFwSikLt70KHsU=",
+      "dev": true,
+      "dependencies": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/testdouble": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.1.tgz",
+      "integrity": "sha512-diaNYjFfR8bdMhtwJ9c2KxHa7M8Al7YciU+kteutWIIendmCC61ZyqQBtprsFkb6Cd/rjBr2sEoUJ8bWIVHm6w==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.4",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/testdouble/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+      "dev": true
+    },
+    "node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/token-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
+      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
+    },
+    "node_modules/uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dependencies": {
+        "source-map": "~0.5.1",
+        "yargs": "~3.10.0"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "optionalDependencies": {
+        "uglify-to-browserify": "~1.0.0"
+      }
+    },
+    "node_modules/uglify-js/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
+    },
+    "node_modules/unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "node_modules/underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/v8flags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/with": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
+      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+      "dependencies": {
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
+      }
+    },
+    "node_modules/with/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    },
+    "node_modules/yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dependencies": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/babel-types": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.9.tgz",
+      "integrity": "sha512-qZLoYeXSTgQuK1h7QQS16hqLGdmqtRmN8w/rl3Au/l5x/zkHx+a4VHrHyBsi1I1vtK2oBHxSzKIu0R5p6spdOA=="
+    },
+    "@types/babylon": {
+      "version": "6.16.5",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
+      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+      "requires": {
+        "@types/babel-types": "*"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+    },
+    "acorn-globals": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "requires": {
+        "acorn": "^4.0.4"
+      }
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "character-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
+      "requires": {
+        "is-regex": "^1.0.3"
+      }
+    },
+    "clean-css": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "requires": {
+        "source-map": "~0.6.0"
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "coffeescript": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz",
+      "integrity": "sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ=="
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "constantinople": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
+      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+      "requires": {
+        "@types/babel-types": "^7.0.0",
+        "@types/babylon": "^6.16.2",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0"
+      }
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "doctypes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "requires": {
+        "glob": "~5.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "fined": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "is-plain-object": "^2.0.3",
+        "object.defaults": "^1.1.0",
+        "object.pick": "^1.2.0",
+        "parse-filepath": "^1.0.1"
+      }
+    },
+    "flagged-respawn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+      "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q=="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "getobject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-1.0.0.tgz",
+      "integrity": "sha512-tbUz6AKKKr2YiMB+fLWIgq5ZeBOobop9YMMAU9dC54/ot2ksMXt3DOFyBuhZw6ptcVszEykgByK20j7W9jHFag=="
+    },
+    "glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "requires": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "grunt": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.0.tgz",
+      "integrity": "sha512-yRFc0GVCDu9yxqOFzpuXQ2pEdgtLDnFv5Qz54jfIcNnpJ8Z7B7P7kPkT4VMuRvm+N+QOsI8C4v/Q0DSaoj3LgQ==",
+      "requires": {
+        "dateformat": "~3.0.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.2",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.1.6",
+        "grunt-cli": "~1.4.2",
+        "grunt-known-options": "~1.1.1",
+        "grunt-legacy-log": "~3.0.0",
+        "grunt-legacy-util": "~2.0.1",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.14.0",
+        "minimatch": "~3.0.4",
+        "mkdirp": "~1.0.4",
+        "nopt": "~3.0.6",
+        "rimraf": "~3.0.2"
+      }
+    },
+    "grunt-cli": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.2.tgz",
+      "integrity": "sha512-wsu6BZh7KCnfeaSkDrKIAvOlqGKxNRTZjc8xfZlvxCByQIqUfZ31kh5uHpPnhQ4NdVgvaWaVxa1LUbVU80nACw==",
+      "requires": {
+        "grunt-known-options": "~1.1.1",
+        "interpret": "~1.1.0",
+        "liftup": "~3.0.1",
+        "nopt": "~4.0.1",
+        "v8flags": "~3.2.0"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        }
+      }
+    },
+    "grunt-jasmine-bundle": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-jasmine-bundle/-/grunt-jasmine-bundle-0.4.0.tgz",
+      "integrity": "sha1-mbLFbTBVHBeK2+b/5oWcUAu+UOg=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "~1.6.3",
+        "jasmine-before-all": "~0.1.0",
+        "jasmine-given": "~2.5.0",
+        "jasmine-only": "~0.1.0",
+        "jasmine-stealth": "~0.0.13",
+        "lodash": "~0.9.0",
+        "minijasminenode": "~1.1.1"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+          "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+          "dev": true
+        },
+        "minijasminenode": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz",
+          "integrity": "sha1-f5Y31mQopTHAX08QtpoxG137YOk=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-known-options": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ=="
+    },
+    "grunt-legacy-log": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-3.0.0.tgz",
+      "integrity": "sha512-GHZQzZmhyq0u3hr7aHW4qUH0xDzwp2YXldLPZTCjlOeGscAOWWPftZG3XioW8MasGp+OBRIu39LFx14SLjXRcA==",
+      "requires": {
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~2.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.1.0.tgz",
+      "integrity": "sha512-lwquaPXJtKQk0rUM1IQAop5noEpwFqOXasVoedLeNzaibf/OPWjKYvvdqnEHNmU+0T0CaReAXIbGo747ZD+Aaw==",
+      "requires": {
+        "chalk": "~4.1.0",
+        "lodash": "~4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-2.0.1.tgz",
+      "integrity": "sha512-2bQiD4fzXqX8rhNdXkAywCadeqiPiay0oQny77wA2F3WF4grPJXCvAcyoWUJV+po/b15glGkxuSiQCK299UC2w==",
+      "requires": {
+        "async": "~3.2.0",
+        "exit": "~0.1.2",
+        "getobject": "~1.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.17.21",
+        "underscore.string": "~3.3.5",
+        "which": "~2.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "underscore.string": {
+          "version": "3.3.5",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+          "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+          "requires": {
+            "sprintf-js": "^1.0.3",
+            "util-deprecate": "^1.0.2"
+          }
+        }
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+    },
+    "highlight.js": {
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
+      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg=="
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk="
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-core-module": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-expression": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
+      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
+      "requires": {
+        "acorn": "~4.0.2",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "is-regex": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "jasmine-before-all": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/jasmine-before-all/-/jasmine-before-all-0.1.2.tgz",
+      "integrity": "sha1-H0UgQfWds2rFZTInw56NGbb8eZ8=",
+      "dev": true
+    },
+    "jasmine-given": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jasmine-given/-/jasmine-given-2.5.1.tgz",
+      "integrity": "sha1-NyD8Jo753AHob65TI9+FKf/MaC4=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "~ 1.6.3",
+        "minijasminenode": "~0.2.4"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+          "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+          "dev": true
+        }
+      }
+    },
+    "jasmine-only": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/jasmine-only/-/jasmine-only-0.1.2.tgz",
+      "integrity": "sha1-kb27r5B8wCjRmVao46c8kUR4O+c=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "~ 1.6.3"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+          "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+          "dev": true
+        }
+      }
+    },
+    "jasmine-stealth": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/jasmine-stealth/-/jasmine-stealth-0.0.17.tgz",
+      "integrity": "sha1-ICp+rnKmwbdbtsCbxdNYrb9Ngnc=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "~ 1.6.3",
+        "minijasminenode": "~0.2.4"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+          "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4=",
+          "dev": true
+        }
+      }
+    },
+    "js-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jstransformer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
+      "requires": {
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+    },
+    "liftup": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/liftup/-/liftup-3.0.1.tgz",
+      "integrity": "sha512-yRHaiQDizWSzoXk3APcA71eOI/UuhEkNN9DiW2Tt44mhYzX4joFoCZlxsSOF7RyeLlfqzFLQI1ngFq3ggMPhOw==",
+      "requires": {
+        "extend": "^3.0.2",
+        "findup-sync": "^4.0.0",
+        "fined": "^1.2.0",
+        "flagged-respawn": "^1.0.1",
+        "is-plain-object": "^2.0.4",
+        "object.map": "^1.0.1",
+        "rechoir": "^0.7.0",
+        "resolve": "^1.19.0"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+          "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "micromatch": "^4.0.2",
+            "resolve-dir": "^1.0.1"
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+    },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "requires": {
+        "kind-of": "^6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "minijasminenode": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-0.2.7.tgz",
+      "integrity": "sha1-U0/UVQGZrGjypw3IfGLarpOT5oE=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "moment": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz",
+      "integrity": "sha1-zBdKq7GSI+//VpmpRngFoniYOL8="
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "requires": {
+        "array-each": "^1.0.1",
+        "array-slice": "^1.0.0",
+        "for-own": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "requires": {
+        "for-own": "^1.0.0",
+        "make-iterator": "^1.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+    },
+    "picomatch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "pug": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
+      "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
+      "requires": {
+        "pug-code-gen": "^2.0.2",
+        "pug-filters": "^3.1.1",
+        "pug-lexer": "^4.1.0",
+        "pug-linker": "^3.0.6",
+        "pug-load": "^2.0.12",
+        "pug-parser": "^5.0.1",
+        "pug-runtime": "^2.0.5",
+        "pug-strip-comments": "^1.0.4"
+      }
+    },
+    "pug-attrs": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
+      "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
+      "requires": {
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.5"
+      }
+    },
+    "pug-code-gen": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.3.tgz",
+      "integrity": "sha512-r9sezXdDuZJfW9J91TN/2LFbiqDhmltTFmGpHTsGdrNGp3p4SxAjjXEfnuK2e4ywYsRIVP0NeLbSAMHUcaX1EA==",
+      "requires": {
+        "constantinople": "^3.1.2",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.4",
+        "pug-error": "^1.3.3",
+        "pug-runtime": "^2.0.5",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
+      }
+    },
+    "pug-error": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
+      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
+    },
+    "pug-filters": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
+      "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
+      "requires": {
+        "clean-css": "^4.1.11",
+        "constantinople": "^3.0.1",
+        "jstransformer": "1.0.0",
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
+      }
+    },
+    "pug-lexer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
+      "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
+      "requires": {
+        "character-parser": "^2.1.1",
+        "is-expression": "^3.0.0",
+        "pug-error": "^1.3.3"
+      }
+    },
+    "pug-linker": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
+      "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
+      "requires": {
+        "pug-error": "^1.3.3",
+        "pug-walk": "^1.1.8"
+      }
+    },
+    "pug-load": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
+      "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
+      "requires": {
+        "object-assign": "^4.1.0",
+        "pug-walk": "^1.1.8"
+      }
+    },
+    "pug-parser": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
+      "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
+      "requires": {
+        "pug-error": "^1.3.3",
+        "token-stream": "0.0.1"
+      }
+    },
+    "pug-runtime": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
+      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
+    },
+    "pug-strip-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
+      "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
+      "requires": {
+        "pug-error": "^1.3.3"
+      }
+    },
+    "pug-walk": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
+      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
+    },
+    "quibble": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.5.tgz",
+      "integrity": "sha512-L3/bDHWjHm9zdG0Aqj7lhmp6Q5RFjXeitO9CGzWKP83d6BlGS0lLo9oswxgq62gwuIF7apT9tO0dw9kNuvb9eg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14",
+        "resolve": "^1.11.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "rechoir": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
+      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "rss": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.0.1.tgz",
+      "integrity": "sha1-63KokwsioOVeKo5qPVl2KF4Sfq0=",
+      "requires": {
+        "mime": "^1.2.11",
+        "xml": "^1.0.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha1-BXw8mpChJzObudFwSikLt70KHsU=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "testdouble": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.1.tgz",
+      "integrity": "sha512-diaNYjFfR8bdMhtwJ9c2KxHa7M8Al7YciU+kteutWIIendmCC61ZyqQBtprsFkb6Cd/rjBr2sEoUJ8bWIVHm6w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.4",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "token-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
+      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "optional": true
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "v8flags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+    },
+    "with": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
+      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+      "requires": {
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "coffeescript": "^2.5.1",
     "grunt": "^1.4.0",
     "highlight.js": "^10.7.2",
-    "marked": "^0.3.6",
+    "marked": "^2.0.3",
     "moment": "~2.8.3",
-    "pug": "^2.0.0-beta6",
-    "rss": "~1.0.0",
+    "pug": "^3.0.2",
+    "rss": "^1.2.2",
     "underscore": "~1.7.0",
     "underscore.string": "~2.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "url": "https://github.com/testdouble/grunt-markdown-blog/issues"
   },
   "dependencies": {
-    "coffee-script": "~1.8.0",
-    "grunt": "~0.4.1",
-    "highlight.js": "^9.7.0",
+    "coffeescript": "^2.5.1",
+    "grunt": "^1.4.0",
+    "highlight.js": "^10.7.2",
     "marked": "^0.3.6",
     "moment": "~2.8.3",
     "pug": "^2.0.0-beta6",
@@ -31,9 +31,8 @@
     "underscore.string": "~2.3.3"
   },
   "devDependencies": {
-    "grunt-jasmine-bundle": "~0.2.0",
-    "grunt-release": "~0.7.0",
-    "sandboxed-module": "~1.0.2"
+    "grunt-jasmine-bundle": "^0.4.0",
+    "testdouble": "^3.16.1"
   },
   "keywords": [
     "gruntplugin",

--- a/spec/archive_spec.coffee
+++ b/spec/archive_spec.coffee
@@ -1,4 +1,4 @@
-Archive = require('../lib/archive')
+Archive = require("../lib/archive")
 
 describe "Archive", ->
   Given -> @htmlPath = "htmlPath"
@@ -8,9 +8,9 @@ describe "Archive", ->
   describe "#writeHtml", ->
     Given -> @html = "html"
     Given ->
-      @generatesHtml = td.object('generatesHtml', ['generate'])
+      @generatesHtml = td.object("generatesHtml", ["generate"])
       td.when(@generatesHtml.generate(@layout)).thenReturn(@html)
-    Given -> @writesFile = td.object('writesFile', ['write'])
+    Given -> @writesFile = td.object("writesFile", ["write"])
 
     When -> @subject.writeHtml(@generatesHtml, @writesFile)
 

--- a/spec/archive_spec.coffee
+++ b/spec/archive_spec.coffee
@@ -6,10 +6,12 @@ describe "Archive", ->
   Given -> @subject = new Archive({@htmlPath, @layout})
 
   describe "#writeHtml", ->
-    Given -> @generatesHtml = jasmine.createStubObj('generatesHtml', generate: @html = "html")
-    Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
+    Given -> @html = "html"
+    Given ->
+      @generatesHtml = td.object('generatesHtml', ['generate'])
+      td.when(@generatesHtml.generate(@layout)).thenReturn(@html)
+    Given -> @writesFile = td.object('writesFile', ['write'])
 
     When -> @subject.writeHtml(@generatesHtml, @writesFile)
 
-    Then -> expect(@generatesHtml.generate).toHaveBeenCalledWith(@layout)
-    Then -> expect(@writesFile.write).toHaveBeenCalledWith(@html, @htmlPath)
+    Then -> td.verify(@writesFile.write(@html, @htmlPath))

--- a/spec/config_spec.coffee
+++ b/spec/config_spec.coffee
@@ -51,7 +51,7 @@ describe "Config", ->
           index: undefined
           post: null
           page: false
-          # archive: ""
+          archive: undefined
       Then -> expect(@subject.raw).toEqual
         author: "top level"
         description: "description"

--- a/spec/config_spec.coffee
+++ b/spec/config_spec.coffee
@@ -1,4 +1,4 @@
-Config = require('../lib/config')
+Config = require("../lib/config")
 
 describe "Config", ->
   Given -> @options = layouts: {}, paths: {}, pathRoots: {}
@@ -13,7 +13,7 @@ describe "Config", ->
         description: "the blog where I write things"
         url: "http://www.myblog.com"
         rssCount: 10
-        dateFormat: 'MMMM Do YYYY'
+        dateFormat: "MMMM Do YYYY"
         layouts:
           wrapper: "app/templates/wrapper.pug"
           index: "app/templates/index.pug"

--- a/spec/factory_spec.coffee
+++ b/spec/factory_spec.coffee
@@ -1,17 +1,23 @@
 Factory = null
 grunt = null
+Archive  = null
+Feed     = null
+Index    = null
+Layout   = null
+NullFeed = null
+NullHtml = null
+Pages    = null
+Posts    = null
 
 beforeEach ->
-  @deps = {
-    Archive : td.constructor("Archive")
-    Feed    : td.constructor("Feed")
-    Index   : td.constructor("Index")
-    Pages   : td.constructor("Pages")
-    Posts   : td.constructor("Posts")
-    NullFeed: td.constructor("NullFeed")
-    NullHtml: td.constructor("NullHtml")
-    Layout  : td.constructor("Layout")
-  }
+  Archive  = td.constructor("Archive")
+  Feed     = td.constructor("Feed")
+  Index    = td.constructor("Index")
+  Layout   = td.constructor("Layout")
+  NullFeed = td.constructor("NullFeed")
+  NullHtml = td.constructor("NullHtml")
+  Pages    = td.constructor("Pages")
+  Posts    = td.constructor("Posts")
 
   Factory  = require("../lib/factory")
 
@@ -28,53 +34,53 @@ Given -> grunt =
     expand: td.func("file-expand")
 
 describe "Factory", ->
-  Given -> @subject = Factory(grunt, @deps)
+  Given -> @subject = Factory(grunt, { Archive, Feed, Index, Pages, Posts, NullFeed, NullHtml, Layout })
 
   describe "::archiveFrom", ->
     When -> @archive = @subject.archiveFrom({@htmlPath, @layoutPath})
 
     context "without htmlPath", ->
       Given -> @htmlPath = undefined
-      Then -> @archive instanceof @deps.NullHtml
+      Then -> @archive instanceof NullHtml
 
     context "with htmlPath", ->
       Given -> @htmlPath = "htmlPath"
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> @archive instanceof @deps.NullHtml
+        Then -> @archive instanceof NullHtml
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> @archive instanceof @deps.NullHtml
+          Then -> @archive instanceof NullHtml
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(@deps.Archive({@htmlPath, layout: td.matchers.isA(@deps.Layout)}))
-          Then -> td.verify(@deps.Layout(@layoutPath))
-          Then -> @archive instanceof @deps.Archive
+          Then -> td.verify(Archive({@htmlPath, layout: td.matchers.isA(Layout)}))
+          Then -> td.verify(Layout(@layoutPath))
+          Then -> @archive instanceof Archive
 
   describe "::feedFrom", ->
     When -> @feed = @subject.feedFrom({@rssPath, @postCount})
 
     context "without rss path", ->
       Given -> @rssPath = undefined
-      Then -> @feed instanceof @deps.NullFeed
+      Then -> @feed instanceof NullFeed
 
     context "with rss path", ->
       Given -> @rssPath = "some/path"
 
       context "without posts", ->
         Given -> @postCount = 0
-        Then -> @feed instanceof @deps.NullFeed
+        Then -> @feed instanceof NullFeed
 
       context "with posts", ->
         Given -> @postCount = 2
-        Then -> td.verify(@deps.Feed({@rssPath, @postCount}))
-        Then -> @feed instanceof @deps.Feed
+        Then -> td.verify(Feed({@rssPath, @postCount}))
+        Then -> @feed instanceof Feed
 
   describe "::indexFrom", ->
     Given -> @latestPost = "latestPost"
@@ -82,27 +88,27 @@ describe "Factory", ->
 
     context "without htmlPath", ->
       Given -> @htmlPath = undefined
-      Then -> @index instanceof @deps.NullHtml
+      Then -> @index instanceof NullHtml
 
     context "with htmlPath", ->
       Given -> @htmlPath = "htmlPath"
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> @index instanceof @deps.NullHtml
+        Then -> @index instanceof NullHtml
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> @index instanceof @deps.NullHtml
+          Then -> @index instanceof NullHtml
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(@deps.Index(@latestPost, {@htmlPath, layout: td.matchers.isA(@deps.Layout)}))
-          Then -> td.verify(@deps.Layout(@layoutPath))
-          Then -> @index instanceof @deps.Index
+          Then -> td.verify(Index(@latestPost, {@htmlPath, layout: td.matchers.isA(Layout)}))
+          Then -> td.verify(Layout(@layoutPath))
+          Then -> @index instanceof Index
 
   describe "::pagesFrom", ->
     Given -> @src = []
@@ -111,26 +117,26 @@ describe "Factory", ->
 
     context "without pages", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = [])
-      Then -> td.verify(@deps.Pages([], {}))
+      Then -> td.verify(Pages([], {}))
 
     context "with pages", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = ["some/page"])
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> td.verify(@deps.Pages([], {}))
+        Then -> td.verify(Pages([], {}))
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> td.verify(@deps.Pages([], {}))
+          Then -> td.verify(Pages([], {}))
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(@deps.Pages(@expandedSrc, {@htmlDir, layout: td.matchers.isA(@deps.Layout)}))
-          Then -> td.verify(@deps.Layout(@layoutPath))
+          Then -> td.verify(Pages(@expandedSrc, {@htmlDir, layout: td.matchers.isA(Layout)}))
+          Then -> td.verify(Layout(@layoutPath))
 
   describe "::postsFrom", ->
     Given -> @src = ["path/to/posts/**/*"]
@@ -141,26 +147,26 @@ describe "Factory", ->
 
     context "without posts", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = [])
-      Then -> td.verify(@deps.Posts([], {}))
+      Then -> td.verify(Posts([], {}))
 
     context "with posts", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = ["some/post"])
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> td.verify(@deps.Posts([], {}))
+        Then -> td.verify(Posts([], {}))
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> td.verify(@deps.Posts([], {}))
+          Then -> td.verify(Posts([], {}))
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(@deps.Posts(@expandedSrc, {@htmlDir, layout: td.matchers.isA(@deps.Layout), @dateFormat}))
-          Then -> td.verify(@deps.Layout(@layoutPath))
+          Then -> td.verify(Posts(@expandedSrc, {@htmlDir, layout: td.matchers.isA(Layout), @dateFormat}))
+          Then -> td.verify(Layout(@layoutPath))
 
   describe "::siteWrapperFrom", ->
     Given -> @context = "context"
@@ -179,4 +185,4 @@ describe "Factory", ->
 
       context "valid", ->
         Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-        Then -> td.verify(@deps.Layout(@layoutPath, @context))
+        Then -> td.verify(Layout(@layoutPath, @context))

--- a/spec/factory_spec.coffee
+++ b/spec/factory_spec.coffee
@@ -1,15 +1,23 @@
-td = require('testdouble')
 { Factory, grunt, Archive, Feed, Index, Pages, Posts, NullFeed, NullHtml, Layout } = {}
 
 beforeEach ->
-  Archive  = td.replace('../lib/archive')
-  Feed     = td.replace('../lib/feed')
-  Index    = td.replace('../lib/index')
-  Pages    = td.replace('../lib/pages')
-  Posts    = td.replace('../lib/posts')
-  NullFeed = td.replace('../lib/null_feed')
-  NullHtml = td.replace('../lib/null_html')
-  Layout   = td.replace('../lib/layout')
+  # this replace syntax might look odd but doing this significantly
+  # sped up the tests, here's a benchmark:
+  #
+  # without an explicit td.constructor
+  # - Finished in 38.471 seconds
+  #
+  # with an explicit td.constructor
+  # - Finished in 23.8 seconds
+
+  Archive  = td.replace('../lib/archive', td.constructor('Archive'))
+  Feed     = td.replace('../lib/feed', td.constructor('Feed'))
+  Index    = td.replace('../lib/index', td.constructor('Index'))
+  Pages    = td.replace('../lib/pages', td.constructor('Pages'))
+  Posts    = td.replace('../lib/posts', td.constructor('Posts'))
+  NullFeed = td.replace('../lib/null_feed', td.constructor('NullFeed'))
+  NullHtml = td.replace('../lib/null_html', td.constructor('NullHtml'))
+  Layout   = td.replace('../lib/layout', td.constructor('Layout'))
   Factory  = require('../lib/factory')
 
 afterEach ->

--- a/spec/factory_spec.coffee
+++ b/spec/factory_spec.coffee
@@ -1,85 +1,80 @@
-{ Factory, grunt, Archive, Feed, Index, Pages, Posts, NullFeed, NullHtml, Layout } = {}
+Factory = null
+grunt = null
 
 beforeEach ->
-  # this replace syntax might look odd but doing this significantly
-  # sped up the tests, here's a benchmark:
-  #
-  # without an explicit td.constructor
-  # - Finished in 38.471 seconds
-  #
-  # with an explicit td.constructor
-  # - Finished in 23.8 seconds
+  @deps = {
+    Archive : td.constructor("Archive")
+    Feed    : td.constructor("Feed")
+    Index   : td.constructor("Index")
+    Pages   : td.constructor("Pages")
+    Posts   : td.constructor("Posts")
+    NullFeed: td.constructor("NullFeed")
+    NullHtml: td.constructor("NullHtml")
+    Layout  : td.constructor("Layout")
+  }
 
-  Archive  = td.replace('../lib/archive', td.constructor('Archive'))
-  Feed     = td.replace('../lib/feed', td.constructor('Feed'))
-  Index    = td.replace('../lib/index', td.constructor('Index'))
-  Pages    = td.replace('../lib/pages', td.constructor('Pages'))
-  Posts    = td.replace('../lib/posts', td.constructor('Posts'))
-  NullFeed = td.replace('../lib/null_feed', td.constructor('NullFeed'))
-  NullHtml = td.replace('../lib/null_html', td.constructor('NullHtml'))
-  Layout   = td.replace('../lib/layout', td.constructor('Layout'))
-  Factory  = require('../lib/factory')
+  Factory  = require("../lib/factory")
 
 afterEach ->
   td.reset()
 
 Given -> grunt =
   log:
-    error: td.func('log-error')
-    writeln: td.func('log-writeln')
-  warn: td.func('warn')
+    error: td.func("log-error")
+    writeln: td.func("log-writeln")
+  warn: td.func("warn")
   file:
-    exists: td.func('file-exists')
-    expand: td.func('file-expand')
+    exists: td.func("file-exists")
+    expand: td.func("file-expand")
 
 describe "Factory", ->
-  Given -> @subject = Factory(grunt)
+  Given -> @subject = Factory(grunt, @deps)
 
   describe "::archiveFrom", ->
     When -> @archive = @subject.archiveFrom({@htmlPath, @layoutPath})
 
     context "without htmlPath", ->
       Given -> @htmlPath = undefined
-      Then -> @archive instanceof NullHtml
+      Then -> @archive instanceof @deps.NullHtml
 
     context "with htmlPath", ->
       Given -> @htmlPath = "htmlPath"
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> @archive instanceof NullHtml
+        Then -> @archive instanceof @deps.NullHtml
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> @archive instanceof NullHtml
+          Then -> @archive instanceof @deps.NullHtml
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(Archive({@htmlPath, layout: td.matchers.isA(Layout)}))
-          Then -> td.verify(Layout(@layoutPath))
-          Then -> @archive instanceof Archive
+          Then -> td.verify(@deps.Archive({@htmlPath, layout: td.matchers.isA(@deps.Layout)}))
+          Then -> td.verify(@deps.Layout(@layoutPath))
+          Then -> @archive instanceof @deps.Archive
 
   describe "::feedFrom", ->
     When -> @feed = @subject.feedFrom({@rssPath, @postCount})
 
     context "without rss path", ->
       Given -> @rssPath = undefined
-      Then -> @feed instanceof NullFeed
+      Then -> @feed instanceof @deps.NullFeed
 
     context "with rss path", ->
       Given -> @rssPath = "some/path"
 
       context "without posts", ->
         Given -> @postCount = 0
-        Then -> @feed instanceof NullFeed
+        Then -> @feed instanceof @deps.NullFeed
 
       context "with posts", ->
         Given -> @postCount = 2
-        Then -> td.verify(Feed({@rssPath, @postCount}))
-        Then -> @feed instanceof Feed
+        Then -> td.verify(@deps.Feed({@rssPath, @postCount}))
+        Then -> @feed instanceof @deps.Feed
 
   describe "::indexFrom", ->
     Given -> @latestPost = "latestPost"
@@ -87,27 +82,27 @@ describe "Factory", ->
 
     context "without htmlPath", ->
       Given -> @htmlPath = undefined
-      Then -> @index instanceof NullHtml
+      Then -> @index instanceof @deps.NullHtml
 
     context "with htmlPath", ->
       Given -> @htmlPath = "htmlPath"
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> @index instanceof NullHtml
+        Then -> @index instanceof @deps.NullHtml
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> @index instanceof NullHtml
+          Then -> @index instanceof @deps.NullHtml
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(Index(@latestPost, {@htmlPath, layout: td.matchers.isA(Layout)}))
-          Then -> td.verify(Layout(@layoutPath))
-          Then -> @index instanceof Index
+          Then -> td.verify(@deps.Index(@latestPost, {@htmlPath, layout: td.matchers.isA(@deps.Layout)}))
+          Then -> td.verify(@deps.Layout(@layoutPath))
+          Then -> @index instanceof @deps.Index
 
   describe "::pagesFrom", ->
     Given -> @src = []
@@ -116,26 +111,26 @@ describe "Factory", ->
 
     context "without pages", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = [])
-      Then -> td.verify(Pages([], {}))
+      Then -> td.verify(@deps.Pages([], {}))
 
     context "with pages", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = ["some/page"])
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> td.verify(Pages([], {}))
+        Then -> td.verify(@deps.Pages([], {}))
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> td.verify(Pages([], {}))
+          Then -> td.verify(@deps.Pages([], {}))
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(Pages(@expandedSrc, {@htmlDir, layout: td.matchers.isA(Layout)}))
-          Then -> td.verify(Layout(@layoutPath))
+          Then -> td.verify(@deps.Pages(@expandedSrc, {@htmlDir, layout: td.matchers.isA(@deps.Layout)}))
+          Then -> td.verify(@deps.Layout(@layoutPath))
 
   describe "::postsFrom", ->
     Given -> @src = ["path/to/posts/**/*"]
@@ -146,26 +141,26 @@ describe "Factory", ->
 
     context "without posts", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = [])
-      Then -> td.verify(Posts([], {}))
+      Then -> td.verify(@deps.Posts([], {}))
 
     context "with posts", ->
       Given -> td.when(grunt.file.expand(@src)).thenReturn(@expandedSrc = ["some/post"])
 
       context "without layout path", ->
         Given -> @layoutPath = undefined
-        Then -> td.verify(Posts([], {}))
+        Then -> td.verify(@deps.Posts([], {}))
 
       context "with layout path", ->
         Given -> @layoutPath = "layoutPath"
 
         context "invalid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(false)
-          Then -> td.verify(Posts([], {}))
+          Then -> td.verify(@deps.Posts([], {}))
 
         context "valid", ->
           Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-          Then -> td.verify(Posts(@expandedSrc, {@htmlDir, layout: td.matchers.isA(Layout), @dateFormat}))
-          Then -> td.verify(Layout(@layoutPath))
+          Then -> td.verify(@deps.Posts(@expandedSrc, {@htmlDir, layout: td.matchers.isA(@deps.Layout), @dateFormat}))
+          Then -> td.verify(@deps.Layout(@layoutPath))
 
   describe "::siteWrapperFrom", ->
     Given -> @context = "context"
@@ -184,4 +179,4 @@ describe "Factory", ->
 
       context "valid", ->
         Given -> td.when(grunt.file.exists(@layoutPath)).thenReturn(true)
-        Then -> td.verify(Layout(@layoutPath, @context))
+        Then -> td.verify(@deps.Layout(@layoutPath, @context))

--- a/spec/feed_spec.coffee
+++ b/spec/feed_spec.coffee
@@ -1,14 +1,18 @@
-Feed = require('../lib/feed')
+Feed = require("../lib/feed")
 
 describe "Feed", ->
   Given -> @rssPath = "some/path"
   Given -> @subject = new Feed({@rssPath, @postCount})
 
   describe "#writeRss", ->
-    Given -> @generatesRss = jasmine.createStubObj('generatesRss', generate: @rss = "rss")
-    Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
+    Given ->
+      @rss = "rss"
+      @generatesRss = td.object("generatesRss", ["generate"])
+      td.when(@generatesRss.generate()).thenReturn(@rss)
+
+    Given ->
+      @writesFile = td.object("writesFile", ["write"])
 
     When -> @subject.writeRss(@generatesRss, @writesFile)
+    Then -> td.verify(@writesFile.write(@rss, @rssPath))
 
-    Then -> expect(@generatesRss.generate).toHaveBeenCalled()
-    Then -> expect(@writesFile.write).toHaveBeenCalledWith(@rss, @rssPath)

--- a/spec/generates_html_spec.coffee
+++ b/spec/generates_html_spec.coffee
@@ -4,13 +4,23 @@ describe "GeneratesHtml", ->
   Given ->
     @site = "siteStub"
     @post = "postStub"
+    @page = "pageStub"
     @fullHtml = "fullHtmlStub"
     @templateHtml = "templateHtmlStub"
     @wrapper = td.object("wrapper", ["htmlFor"])
     @template = td.object("template", ["htmlFor"])
+    @subject = new GeneratesHtml(@site, @wrapper)
 
-  describe "#generate", ->
-    Given -> td.when(@template.htmlFor({ site: @site, post: @post })).thenReturn(@templateHtml)
-    Given -> td.when(@wrapper.htmlFor({ site: @site, post: @post, yield: @templateHtml })).thenReturn(@fullHtml)
-    When -> @resultHtml = new GeneratesHtml(@site, @wrapper).generate(@template, @post)
+  describe "#generate posts", ->
+    Given -> td.when(@template.htmlFor({ site: @site, post: @post, page: @post })).thenReturn(@templateHtml)
+    Given -> td.when(@wrapper.htmlFor({ site: @site, post: @post, page: @post, yield: @templateHtml })).thenReturn(@fullHtml)
+    When -> @resultHtml = @subject.generate(@template, @post)
     Then -> @resultHtml == @fullHtml
+
+  describe "#generate pages", ->
+    Given -> td.when(@template.htmlFor({ site: @site, page: @page, post: @page })).thenReturn(@templateHtml)
+    Given -> td.when(@wrapper.htmlFor({ site: @site, page: @page, post: @page, yield: @templateHtml })).thenReturn(@fullHtml)
+    When -> @resultHtml = @subject.generate(@template, @page)
+    Then -> @resultHtml == @fullHtml
+
+

--- a/spec/generates_html_spec.coffee
+++ b/spec/generates_html_spec.coffee
@@ -1,21 +1,16 @@
-GeneratesHtml = require('../lib/generates_html')
+GeneratesHtml = require("../lib/generates_html")
 
 describe "GeneratesHtml", ->
-  Given -> @site = "siteStub"
-  Given -> @fullHtml = "fullHtmlStub"
-  Given -> @wrapper = jasmine.createStubObj("wrapper", htmlFor: @fullHtml)
+  Given ->
+    @site = "siteStub"
+    @post = "postStub"
+    @fullHtml = "fullHtmlStub"
+    @templateHtml = "templateHtmlStub"
+    @wrapper = td.object("wrapper", ["htmlFor"])
+    @template = td.object("template", ["htmlFor"])
 
   describe "#generate", ->
-    Given -> @post = "postStub"
-    Given -> @templateHtml = "templateHtmlStub"
-    Given -> @template = jasmine.createStubObj("template", htmlFor: @templateHtml)
-
+    Given -> td.when(@template.htmlFor({ site: @site, post: @post })).thenReturn(@templateHtml)
+    Given -> td.when(@wrapper.htmlFor({ site: @site, post: @post, yield: @templateHtml })).thenReturn(@fullHtml)
     When -> @resultHtml = new GeneratesHtml(@site, @wrapper).generate(@template, @post)
-
-    Then -> expect(@template.htmlFor).toHaveBeenCalledWith jasmine.argThat (context) =>
-        context.site == @site && context.post == @post
-
-    Then -> expect(@wrapper.htmlFor).toHaveBeenCalledWith jasmine.argThat (context) =>
-        context.site == @site && context.post == @post && context.yield == @templateHtml
-
     Then -> @resultHtml == @fullHtml

--- a/spec/generates_rss_spec.coffee
+++ b/spec/generates_rss_spec.coffee
@@ -1,4 +1,3 @@
-td = require('testdouble')
 Rss = null
 GeneratesRss = null
 
@@ -15,6 +14,7 @@ describe "GeneratesRss", ->
       rss: "path/feed.xml"
     author: "author"
     posts: []
+    getPosts: -> []
     urlFor: (post) -> "url/#{post.title()}"
 
   When -> @subject = new GeneratesRss(@site, Rss)
@@ -28,7 +28,7 @@ describe "GeneratesRss", ->
   Then -> @feed == @feedXml
 
   context "with posts", ->
-    Given -> @site.posts = [
+    Given -> @site.getPosts = -> [
       {
         title: -> "post1 title"
         content: -> "post1 content"

--- a/spec/generates_rss_spec.coffee
+++ b/spec/generates_rss_spec.coffee
@@ -1,10 +1,10 @@
+td = require('testdouble')
 Rss = null
 GeneratesRss = null
-SandboxedModule = require('sandboxed-module')
 
-Given -> Rss = jasmine.constructSpy('Rss', ['item', 'xml'])
-Given -> Rss::xml.andReturn(@feedXml = "feedXml")
-Given -> GeneratesRss = SandboxedModule.require '../lib/generates_rss', requires: 'rss': Rss
+Given -> Rss = td.constructor(['item', 'xml'])
+Given -> td.when(Rss::xml()).thenReturn(@feedXml = "feedXml")
+Given -> GeneratesRss = require '../lib/generates_rss'
 
 describe "GeneratesRss", ->
   Given -> @site =
@@ -15,53 +15,42 @@ describe "GeneratesRss", ->
       rss: "path/feed.xml"
     author: "author"
     posts: []
-    urlFor: @urlFor = jasmine.createSpy('site.urlFor').andCallFake (post) -> "url/#{post.title()}"
+    urlFor: (post) -> "url/#{post.title()}"
 
-  When -> @subject = new GeneratesRss @site
+  When -> @subject = new GeneratesRss(@site, Rss)
   When -> @feed = @subject.generate()
-  Then -> expect(Rss).toHaveBeenCalledWith
+  Then -> td.verify Rss
     title: "title"
     description: "description"
     feed_url: "url/path/feed.xml"
     site_url: "url"
     author: "author"
-  Then -> expect(Rss::xml).toHaveBeenCalled()
   Then -> @feed == @feedXml
-
-  context "with no posts", ->
-    Given -> @site.posts = []
-    Then -> expect(Rss::item).not.toHaveBeenCalled()
 
   context "with posts", ->
     Given -> @site.posts = [
-      @post1 = jasmine.createStubObj 'post1',
-        title: "post1 title", content: "post1 content", time: "post1 time"
-      @post2 = jasmine.createStubObj 'post2',
-        title: "post2 title", content: "post2 content", time: "post2 time"
+      {
+        title: -> "post1 title"
+        content: -> "post1 content"
+        time: -> "post1 time"
+      },
+      {
+        title: -> "post2 title"
+        content: -> "post2 content"
+        time: -> "post2 time"
+      }
     ]
-
-    context "rssCount = 0", ->
-      Given -> @site.rssCount = 0
-      Then -> expect(Rss::item).not.toHaveBeenCalled()
 
     context "rssCount less than number of posts", ->
       Given -> @site.rssCount = 1
-      Then -> Rss::item.callCount == 1
-      Then -> expect(Rss::item).toHaveBeenCalledWith
-        title: "post2 title", description: "post2 content", url: "url/post2 title", date: "post2 time"
+      Then -> td.verify Rss::item { title: "post2 title", description: "post2 content", url: "url/post2 title", date: "post2 time" }
 
     context "rssCount equal to number of posts", ->
       Given -> @site.rssCount = 2
-      Then -> Rss::item.callCount == 2
-      Then -> expect(Rss::item).toHaveBeenCalledWith
-        title: "post1 title", description: "post1 content", url: "url/post1 title", date: "post1 time"
-      And -> expect(Rss::item).toHaveBeenCalledWith
-        title: "post2 title", description: "post2 content", url: "url/post2 title", date: "post2 time"
+      Then -> td.verify Rss::item { title: "post1 title", description: "post1 content", url: "url/post1 title", date: "post1 time" }
+      Then -> td.verify Rss::item { title: "post2 title", description: "post2 content", url: "url/post2 title", date: "post2 time" }
 
     context "rssCount greater than number of posts", ->
       Given -> @site.rssCount = 3
-      Then -> Rss::item.callCount == 2
-      Then -> expect(Rss::item).toHaveBeenCalledWith
-        title: "post1 title", description: "post1 content", url: "url/post1 title", date: "post1 time"
-      And -> expect(Rss::item).toHaveBeenCalledWith
-        title: "post2 title", description: "post2 content", url: "url/post2 title", date: "post2 time"
+      Then -> td.verify Rss::item { title: "post1 title", description: "post1 content", url: "url/post1 title", date: "post1 time" }
+      Then -> td.verify Rss::item { title: "post2 title", description: "post2 content", url: "url/post2 title", date: "post2 time" }

--- a/spec/generates_rss_spec.coffee
+++ b/spec/generates_rss_spec.coffee
@@ -1,9 +1,9 @@
 Rss = null
 GeneratesRss = null
 
-Given -> Rss = td.constructor(['item', 'xml'])
+Given -> Rss = td.constructor(["item", "xml"])
 Given -> td.when(Rss::xml()).thenReturn(@feedXml = "feedXml")
-Given -> GeneratesRss = require '../lib/generates_rss'
+Given -> GeneratesRss = require "../lib/generates_rss"
 
 describe "GeneratesRss", ->
   Given -> @site =

--- a/spec/helpers/globals.coffee
+++ b/spec/helpers/globals.coffee
@@ -1,0 +1,1 @@
+global.td = require("testdouble")

--- a/spec/helpers/spies.coffee
+++ b/spec/helpers/spies.coffee
@@ -1,3 +1,5 @@
+global.td = require('testdouble')
+
 jasmine.constructSpy = (classNameToFake, methodsToSpy = []) ->
   spies = class extends jasmine.createSpy(classNameToFake)
   methodsToSpy.forEach (methodName) ->

--- a/spec/helpers/spies.coffee
+++ b/spec/helpers/spies.coffee
@@ -1,7 +1,0 @@
-global.td = require('testdouble')
-
-jasmine.constructSpy = (classNameToFake, methodsToSpy = []) ->
-  spies = class extends jasmine.createSpy(classNameToFake)
-  methodsToSpy.forEach (methodName) ->
-    spies::[methodName] = jasmine.createSpy("#{classNameToFake}##{methodName}")
-  spies

--- a/spec/index_spec.coffee
+++ b/spec/index_spec.coffee
@@ -1,4 +1,4 @@
-Index = require('../lib/index')
+Index = require("../lib/index")
 
 describe "Index", ->
   Given -> @latestPost = "latestPost"
@@ -7,10 +7,10 @@ describe "Index", ->
   Given -> @subject = new Index(@latestPost, {@htmlPath, @layout})
 
   describe "#writeHtml", ->
-    Given -> @generatesHtml = jasmine.createStubObj('generatesHtml', generate: @html = "html")
-    Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
-
+    Given ->
+      @html = "html"
+      @generatesHtml = td.object("generatesHtml", ["generate"])
+      td.when(@generatesHtml.generate(@layout, @latestPost)).thenReturn(@html)
+    Given -> @writesFile = td.object("writesFile", ["write"])
     When -> @subject.writeHtml(@generatesHtml, @writesFile)
-
-    Then -> expect(@generatesHtml.generate).toHaveBeenCalledWith(@layout, @latestPost)
-    Then -> expect(@writesFile.write).toHaveBeenCalledWith(@html, @htmlPath)
+    Then -> td.verify(@writesFile.write(@html, @htmlPath))

--- a/spec/markdown_spec.coffee
+++ b/spec/markdown_spec.coffee
@@ -1,9 +1,9 @@
 Markdown = null
 
 beforeEach ->
-  @compiler = td.func('compiler')
-  @splitter = td.constructor(['split'])
-  Markdown = require '../lib/markdown'
+  @compiler = td.func("compiler")
+  @splitter = td.constructor(["split"])
+  Markdown = require "../lib/markdown"
 
 afterEach ->
   td.reset()

--- a/spec/markdown_spec.coffee
+++ b/spec/markdown_spec.coffee
@@ -1,17 +1,19 @@
 Markdown = null
-td = require('testdouble')
+
+beforeEach ->
+  @compiler = td.func('compiler')
+  @splitter = td.constructor(['split'])
+  Markdown = require '../lib/markdown'
+
+afterEach ->
+  td.reset()
 
 describe "Markdown", ->
-  Given ->
-    @compiler = td.func('compiler')
-    @splitter = td.constructor(['split'])
-    Markdown = require '../lib/markdown'
-
   Given -> @header = "attributes"
   Given -> @markdown = "markdown"
-  Given -> td.when(@splitter::split(td.matchers.anything())).thenReturn({@header, @markdown})
 
   describe "#compile", ->
+    Given -> td.when(@splitter::split(td.matchers.anything())).thenReturn({@header, @markdown})
     Given -> @subject = new Markdown("input source", @compiler, @splitter)
     When -> @subject.compile()
     Then -> @subject.header == @header

--- a/spec/markdown_splitter_spec.coffee
+++ b/spec/markdown_splitter_spec.coffee
@@ -1,5 +1,3 @@
-td = require('testdouble')
-
 Given ->
   MarkdownSplitter = require '../lib/markdown_splitter'
   logger = td.object(['warn'])

--- a/spec/markdown_splitter_spec.coffee
+++ b/spec/markdown_splitter_spec.coffee
@@ -1,10 +1,9 @@
-SandboxedModule = require('sandboxed-module')
+td = require('testdouble')
 
 Given ->
-  MarkdownSplitter = SandboxedModule.require '../lib/markdown_splitter',
-    singleOnly: true
-    requires: grunt: @grunt = jasmine.createSpyObj('grunt', ['warn'])
-  @subject = new MarkdownSplitter
+  MarkdownSplitter = require '../lib/markdown_splitter'
+  logger = td.object(['warn'])
+  @subject = new MarkdownSplitter(logger)
 
 describe "splitting up markdown files", ->
 
@@ -60,7 +59,6 @@ describe "splitting up markdown files", ->
                           Post stuff
                           """
       Then -> expect(=> @subject.split(@fixture)).toThrow()
-      And -> expect(@grunt.warn).toHaveBeenCalled()
 
 
   describe "it removes the header", ->
@@ -74,7 +72,7 @@ describe "splitting up markdown files", ->
                         Post stuff
                         """
     When -> @result = @subject.split(@fixture)
-    Then -> expect(@result.markdown.trim()).toEqual """
+    Then -> @result.markdown.trim() == """
                                                     # My post stuff
 
                                                     Post stuff

--- a/spec/markdown_splitter_spec.coffee
+++ b/spec/markdown_splitter_spec.coffee
@@ -1,6 +1,6 @@
 Given ->
-  MarkdownSplitter = require '../lib/markdown_splitter'
-  logger = td.object(['warn'])
+  MarkdownSplitter = require "../lib/markdown_splitter"
+  logger = td.object(["warn"])
   @subject = new MarkdownSplitter(logger)
 
 describe "splitting up markdown files", ->
@@ -23,10 +23,9 @@ describe "splitting up markdown files", ->
                           Post stuff
                           """
       When -> @result = @subject.split(@fixture)
-      Then -> expect(@result.header).toEqual
-        foo: "bar"
-        baz: 5
-        biz: jasmine.argThat (fe) -> fe() == "beez"
+      Then -> @result.header.foo == "bar"
+      And -> @result.header.baz == 5
+      And -> @result.header.biz() == "beez"
 
     context "coffeescript", ->
       Given -> @fixture = """
@@ -41,10 +40,9 @@ describe "splitting up markdown files", ->
                           Post stuff
                           """
       When -> @result = @subject.split(@fixture)
-      Then -> expect(@result.header).toEqual
-        foo: "bar"
-        baz: 5
-        biz: jasmine.argThat (fe) -> fe() == "beez"
+      Then -> @result.header.foo == "bar"
+      And -> @result.header.baz == 5
+      And -> @result.header.biz() == "beez"
 
     context "neither", ->
       Given -> @fixture = """

--- a/spec/page_spec.coffee
+++ b/spec/page_spec.coffee
@@ -1,23 +1,29 @@
 Page = null
-td = require('testdouble')
+reader = null
+Markdown = null
+
+beforeEach ->
+  Markdown = td.replace('../lib/markdown', td.constructor(['compile']))
+  @reader = td.object('reader', ['read'])
+  Page = require('../lib/page')
+
+afterEach ->
+  td.reset()
 
 describe "Page", ->
   Given ->
     @reader = td.object(['read'])
-    @markdown = td.replace('../lib/markdown')
-    Page = require '../lib/page'
 
   describe "#constructor", ->
     Given -> @path = "path"
     Given -> td.when(@reader.read(@path)).thenReturn(@source = "source")
-    Given -> @markdown::header = @header = "attributes"
     When -> @subject = new Page(@path, '', '', @reader)
-    Then -> td.verify(@markdown(@source))
+    Then -> td.verify(Markdown(@source))
     Then -> @subject.attributes == @header
 
   describe "#content", ->
     Given -> @subject = new Page('', '', '', @reader)
-    When -> td.when(@markdown::compile()).thenReturn(@parsedMarkdown = "content")
+    When -> td.when(@subject._markdown.compile()).thenReturn(@parsedMarkdown = "content")
     Then -> @subject.content() == @parsedMarkdown
 
   describe "#get", ->

--- a/spec/page_spec.coffee
+++ b/spec/page_spec.coffee
@@ -3,32 +3,32 @@ reader = null
 Markdown = null
 
 beforeEach ->
-  Markdown = td.replace('../lib/markdown', td.constructor(['compile']))
-  @reader = td.object('reader', ['read'])
-  Page = require('../lib/page')
+  Markdown = td.replace("../lib/markdown", td.constructor(["compile"]))
+  @reader = td.object("reader", ["read"])
+  Page = require("../lib/page")
 
 afterEach ->
   td.reset()
 
 describe "Page", ->
   Given ->
-    @reader = td.object(['read'])
+    @reader = td.object(["read"])
 
   describe "#constructor", ->
     Given -> @path = "path"
     Given -> td.when(@reader.read(@path)).thenReturn(@source = "source")
-    When -> @subject = new Page(@path, '', '', @reader)
+    When -> @subject = new Page(@path, "", "", @reader)
     Then -> td.verify(Markdown(@source))
     Then -> @subject.attributes == @header
 
   describe "#content", ->
-    Given -> @subject = new Page('', '', '', @reader)
+    Given -> @subject = new Page("", "", "", @reader)
     When -> td.when(@subject._markdown.compile()).thenReturn(@parsedMarkdown = "content")
     Then -> @subject.content() == @parsedMarkdown
 
   describe "#get", ->
-    Given -> @subject = new Page('', '', '', @reader)
-    When -> @myattr = @subject.get('myattr')
+    Given -> @subject = new Page("", "", "", @reader)
+    When -> @myattr = @subject.get("myattr")
 
     context "undefined attribute", ->
       Given -> @subject.attributes = {}
@@ -51,7 +51,7 @@ describe "Page", ->
       Then -> @myattr == @value()
 
   describe "#title", ->
-    Given -> @subject = new Page('', '', '', @reader)
+    Given -> @subject = new Page("", "", "", @reader)
     When -> @title = @subject.title()
 
     context "from attribute", ->
@@ -71,7 +71,7 @@ describe "Page", ->
       Then -> @title == "path.html"
 
   describe "#htmlPath", ->
-    Given -> @subject = new Page("#{@path = "path/to/pages"}/#{@name = "page"}.md", '', '', @reader)
+    Given -> @subject = new Page("#{@path = "path/to/pages"}/#{@name = "page"}.md", "", "", @reader)
     When -> @htmlPath = @subject.htmlPath()
 
     context "with wildcards in htmlDirPath", ->
@@ -83,9 +83,9 @@ describe "Page", ->
       Then -> @htmlPath == "#{@subject.htmlDirPath}/#{@name}.html"
 
   describe "#fileName", ->
-    Given -> @subject = new Page("/path/to/pages/mypage.md", '', '', @reader)
+    Given -> @subject = new Page("/path/to/pages/mypage.md", "", "", @reader)
     Then -> @subject.fileName() == "mypage.html"
 
   describe "#date", ->
-    Given -> @subject = new Page('', '', '', @reader)
+    Given -> @subject = new Page("", "", "", @reader)
     Then -> @subject.date() == undefined

--- a/spec/page_spec.coffee
+++ b/spec/page_spec.coffee
@@ -23,7 +23,7 @@ describe "Page", ->
 
   describe "#content", ->
     Given -> @subject = new Page("", "", "", @reader)
-    When -> td.when(@subject._markdown.compile()).thenReturn(@parsedMarkdown = "content")
+    When -> td.when(@subject.markdown.compile()).thenReturn(@parsedMarkdown = "content")
     Then -> @subject.content() == @parsedMarkdown
 
   describe "#get", ->

--- a/spec/pages_spec.coffee
+++ b/spec/pages_spec.coffee
@@ -27,7 +27,7 @@ describe "Pages", ->
     Given -> @html = "html"
     Given ->
       @config.layout.htmlFor = td.function("layout.htmlFor")
-      td.when(@config.layout.htmlFor(site: @site, post: @page)).thenReturn(@html)
+      td.when(@config.layout.htmlFor(site: @site, page: @page)).thenReturn(@html)
     When -> @htmlFor = @subject.htmlFor(@site, @page)
     Then -> @htmlFor == @html
 

--- a/spec/pages_spec.coffee
+++ b/spec/pages_spec.coffee
@@ -1,59 +1,59 @@
-spy = jasmine.createSpy
-Page = null
-Pages = null
-SandboxedModule = require('sandboxed-module')
+# spy = jasmine.createSpy
+# Page = null
+# Pages = null
+# SandboxedModule = require('sandboxed-module')
 
-beforeEach ->
-  Pages = SandboxedModule.require '../lib/pages',
-    requires:
-      './page': Page = jasmine.constructSpy("Page", ["fileName"])
+# beforeEach ->
+#   Pages = SandboxedModule.require '../lib/pages',
+#     requires:
+#       './page': Page = jasmine.constructSpy("Page", ["fileName"])
 
-describe "Pages", ->
-  Given -> @config = jasmine.createSpyObj 'config', ['htmlDir', 'layout']
-  Given -> @markdownFiles = [ spy(), spy() ]
+# describe "Pages", ->
+#   Given -> @config = jasmine.createSpyObj 'config', ['htmlDir', 'layout']
+#   Given -> @markdownFiles = [ spy(), spy() ]
 
-  When -> @subject = new Pages(@markdownFiles, @config)
+#   When -> @subject = new Pages(@markdownFiles, @config)
 
-  describe "is array-like", ->
-    Then -> @subject instanceof Pages
-    Then -> @subject instanceof Array
-    Then -> @subject.length == 2
-
-
-  describe "builds pages", ->
-    Given -> @markdownFiles = [ @page = spy('page') ]
-
-    Then -> @subject[0] instanceof Page
-    Then -> expect(Page).toHaveBeenCalledWith(@page, @config.htmlDir)
+#   describe "is array-like", ->
+#     Then -> @subject instanceof Pages
+#     Then -> @subject instanceof Array
+#     Then -> @subject.length == 2
 
 
-  describe "#htmlFor", ->
-    Given -> @site = "site"
-    Given -> @page = "page"
-    Given -> @html = "html"
-    Given -> @config.layout.htmlFor = jasmine.createSpy('layout.htmlFor').andReturn(@html)
-    When -> @htmlFor = @subject.htmlFor(@site, @page)
-    Then -> expect(@config.layout.htmlFor).toHaveBeenCalledWith(site: @site, post: @page)
-    Then -> @htmlFor == @html
+#   describe "builds pages", ->
+#     Given -> @markdownFiles = [ @page = spy('page') ]
+
+#     Then -> @subject[0] instanceof Page
+#     Then -> expect(Page).toHaveBeenCalledWith(@page, @config.htmlDir)
 
 
-  describe "#writeHtml", ->
-    Given -> @html = "html"
-    Given -> @generatesHtml = jasmine.createStubObj('generatesHtml', generate: @html)
-    Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
+#   describe "#htmlFor", ->
+#     Given -> @site = "site"
+#     Given -> @page = "page"
+#     Given -> @html = "html"
+#     Given -> @config.layout.htmlFor = jasmine.createSpy('layout.htmlFor').andReturn(@html)
+#     When -> @htmlFor = @subject.htmlFor(@site, @page)
+#     Then -> expect(@config.layout.htmlFor).toHaveBeenCalledWith(site: @site, post: @page)
+#     Then -> @htmlFor == @html
 
-    context "without pages", ->
-      Given -> @markdownFiles = []
-      When -> @subject.writeHtml(@generatesHtml, @writesFile)
-      Then -> expect(@generatesHtml.generate).not.toHaveBeenCalled()
-      Then -> expect(@writesFile.write).not.toHaveBeenCalled()
 
-    context "with 3 pages", ->
-      Given -> @htmlPath = "htmlPath"
-      Given -> @page = jasmine.createStubObj('page', htmlPath: @htmlPath)
-      When -> @subject.splice 0, @subject.length, @page, @page, @page
-      When -> @subject.writeHtml(@generatesHtml, @writesFile)
-      Then -> @generatesHtml.generate.callCount == 3
-      Then -> expect(@generatesHtml.generate).toHaveBeenCalledWith(@config.layout, @page)
-      Then -> @writesFile.write.callCount == 3
-      Then -> expect(@writesFile.write).toHaveBeenCalledWith(@html, @htmlPath)
+#   describe "#writeHtml", ->
+#     Given -> @html = "html"
+#     Given -> @generatesHtml = jasmine.createStubObj('generatesHtml', generate: @html)
+#     Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
+
+#     context "without pages", ->
+#       Given -> @markdownFiles = []
+#       When -> @subject.writeHtml(@generatesHtml, @writesFile)
+#       Then -> expect(@generatesHtml.generate).not.toHaveBeenCalled()
+#       Then -> expect(@writesFile.write).not.toHaveBeenCalled()
+
+#     context "with 3 pages", ->
+#       Given -> @htmlPath = "htmlPath"
+#       Given -> @page = jasmine.createStubObj('page', htmlPath: @htmlPath)
+#       When -> @subject.splice 0, @subject.length, @page, @page, @page
+#       When -> @subject.writeHtml(@generatesHtml, @writesFile)
+#       Then -> @generatesHtml.generate.callCount == 3
+#       Then -> expect(@generatesHtml.generate).toHaveBeenCalledWith(@config.layout, @page)
+#       Then -> @writesFile.write.callCount == 3
+#       Then -> expect(@writesFile.write).toHaveBeenCalledWith(@html, @htmlPath)

--- a/spec/path_spec.coffee
+++ b/spec/path_spec.coffee
@@ -1,4 +1,4 @@
-Path = require('../lib/path')
+Path = require("../lib/path")
 
 describe "Path", ->
 

--- a/spec/post_spec.coffee
+++ b/spec/post_spec.coffee
@@ -1,11 +1,10 @@
 Post = null
-SandboxedModule = require('sandboxed-module')
+td = require('testdouble')
 
 describe "Post", ->
   beforeEach ->
-    Post = SandboxedModule.require '../lib/post',
-      requires:
-        './../lib/page': class
+    Page = td.replace '../lib/page'
+    Post = require '../lib/post'
 
   Given -> @subject = new Post
 

--- a/spec/post_spec.coffee
+++ b/spec/post_spec.coffee
@@ -1,10 +1,9 @@
 Page = null
 Post = null
 
-
 beforeEach ->
-  Page = td.replace('../lib/page')
-  Post = require '../lib/post'
+  Page = td.replace("../lib/page")
+  Post = require "../lib/post"
 
 afterEach ->
   td.reset()
@@ -13,10 +12,10 @@ describe "Post", ->
   Given -> @subject = new Post
 
   describe "#time", ->
-    Given -> @subject.get = jasmine.createSpy('get')
+    Given -> @subject.get = td.function("get")
 
     context "with date attribute", ->
-      Given -> @subject.get.when("date").thenReturn(@time = "2000-01-01")
+      Given -> td.when(@subject.get("date")).thenReturn(@time = "2000-01-01")
 
       context "with filename date", ->
         Given -> @subject.path = "app/posts/1999-01-01-some-title"
@@ -27,7 +26,7 @@ describe "Post", ->
         Then -> @subject.time() == @time
 
     context "without date attribute", ->
-      Given -> @subject.get.when("date").thenReturn(undefined)
+      Given -> td.when(@subject.get("date")).thenReturn(undefined)
 
       context "with filename date", ->
         Given -> @subject.path = "app/posts/1999-01-01-some-title"

--- a/spec/post_spec.coffee
+++ b/spec/post_spec.coffee
@@ -1,11 +1,15 @@
+Page = null
 Post = null
-td = require('testdouble')
+
+
+beforeEach ->
+  Page = td.replace('../lib/page')
+  Post = require '../lib/post'
+
+afterEach ->
+  td.reset()
 
 describe "Post", ->
-  beforeEach ->
-    Page = td.replace '../lib/page'
-    Post = require '../lib/post'
-
   Given -> @subject = new Post
 
   describe "#time", ->

--- a/spec/posts_spec.coffee
+++ b/spec/posts_spec.coffee
@@ -1,92 +1,93 @@
-# Post = null
-# Posts = null
+Post = null
+Posts = null
 
-# beforeEach ->
-#   Post  = td.constructor(['fileName'])
-#   Posts = require '../lib/posts'
+beforeEach ->
+  Post  = td.replace("../lib/post", td.constructor(["fileName"]))
+  Posts = require "../lib/posts"
 
-# ddescribe "Posts", ->
-#   Given -> @markdownFiles = [ "md1", "md2" ]
-#   Given -> @config = td.object 'config', ['htmlDir', 'layout', 'dateFormat', 'comparator']
-#   When  -> @subject = new Posts(@markdownFiles, @config)
+afterEach ->
+  td.reset()
 
-#   describe "has posts", ->
-#     When -> console.log(@subject)
-#     Then -> @subject.posts.length == 2
+describe "Posts", ->
+  Given -> @config = td.object "config", ["htmlDir", "layout", "dateFormat", "comparator"]
+  Given -> @markdownFiles = [ "post1", "post2" ]
+  When  -> @subject = new Posts(@markdownFiles, @config)
 
-  # describe "builds posts", ->
-  #   Given -> @markdownFiles = [ @post1 = td.object('post1') ]
+  describe "has posts", ->
+    Then -> @subject.posts.length == 2
 
-  #   Then -> @subject.getPosts()[0] instanceof Post
-  #   Then -> td.verify(Post(@post1, @config.htmlDir, @config.dateFormat))
+  describe "builds posts", ->
+    Given -> @markdownFiles = [ "post1" ]
+    Then -> @subject.posts[0] instanceof Post
+    Then -> td.verify(Post("post1", @config.htmlDir, @config.dateFormat))
 
-  # describe "is sorted automatically", ->
-  #   Then -> expect(@config.comparator).toHaveBeenCalled()
+  describe "is sorted automatically", ->
+    Then -> td.verify(@config.comparator(td.matchers.isA(Post), td.matchers.isA(Post)))
 
+  describe "#htmlFor", ->
+    Given -> @site = "site"
+    Given -> @post = "post"
+    Given -> @html = "html"
+    Given ->
+      @config.layout.htmlFor = td.function("layout.htmlFor")
+      td.when(@config.layout.htmlFor(site: @site, post: @post)).thenReturn(@html)
+    When -> @htmlFor = @subject.htmlFor(@site, @post)
+    Then -> @htmlFor == @html
 
-  # describe "#htmlFor", ->
-  #   Given -> @site = "site"
-  #   Given -> @post = "post"
-  #   Given -> @html = "html"
-  #   Given ->
-  #     @config.layout.htmlFor = td.func('layout.htmlFor')
-  #     td.when(@config.layout.htmlFor(@site, @post).thenReturn(@html))
-  #   Then -> @subject.htmlFor(@site, @post) == @html
+  describe "#writeHtml", ->
+    Given -> @html = "html"
+    Given -> @generatesHtml = td.object("generatesHtml", ["generate"])
+    Given -> @writesFile = td.object("writesFile", ["write"])
 
-  # describe "#writeHtml", ->
-  #   Given -> @html = "html"
-  #   Given -> @generatesHtml = td.object('generatesHtml', ['generate'])
-  #   Given -> @writesFile = td.object('writesFile', ['write'])
+    context "without pages", ->
+      Given -> @markdownFiles = []
+      When -> @subject.writeHtml(@generatesHtml, @writesFile)
+      Then -> td.verify(@generatesHtml.generate(), {times: 0, ignoreExtraArgs: true })
+      Then -> td.verify(@writesFile.write(), {times: 0, ignoreExtraArgs: true })
 
-  #   context "without posts", ->
-  #     Given -> @markdownFiles = []
-  #     When -> @subject.writeHtml(@generatesHtml, @writesFile)
-  #     Then -> @generatesHtml.callCount == 0
-  #     Then -> @writesFile.callCount == 0
+    context "with 3 posts", ->
+      Given -> @htmlPath = "htmlPath"
+      Given ->
+        @post = td.object("post", ["htmlPath"])
+        td.when(@post.htmlPath()).thenReturn(@htmlPath)
+      When ->
+        @subject.posts = [@post, @post, @post]
+        @subject.posts.layout = @config.layout
+      When ->
+        td.when(@generatesHtml.generate(@config.layout, @post)).thenReturn(@html)
+      When -> @subject.writeHtml(@generatesHtml, @writesFile)
+      Then -> td.verify(@writesFile.write(@html, @htmlPath), { times: 3})
 
-  #   context "with 3 posts", ->
-  #     Given -> @htmlPath = "htmlPath"
-  #     Given ->
-  #       @post = td.object('post', ['htmlPath'])
-  #       td.when(@post.htmlPath()).thenReturn(@htmlPath)
-  #     Given ->
-  #       @subject.posts = [@post, @post, @post]
-  #     When -> @subject.writeHtml(@generatesHtml, @writesFile)
-  #     Then -> @generatesHtml.generate.callCount == 3
-  #     Then -> td.verify(@generatesHtml.generate(@config.layout, @post))
-  #     Then -> @writesFile.write.callCount == 3
-  #     Then -> td.verify(@writesFile.write(@html, @htmlPath))
+  describe "", ->
+    Given -> [@post1, @post2, @post3] = ["oldest", "middle", "newest"]
+    When -> @subject.posts = [@post1, @post2, @post3]
 
-  # describe '', ->
-  #   Given -> [@post1, @post2, @post3] = ["oldest", "middle", "newest"]
-  #   When -> @subject.posts = [@post1, @post2, @post3]
+    describe "#oldest", ->
+      When -> @oldest = @subject.oldest()
+      Then -> @oldest == @post1
 
-  #   describe "#oldest", ->
-  #     When -> @oldest = @subject.oldest()
-  #     Then -> @oldest == @post1
+    describe "#newest", ->
+      When -> @newest = @subject.newest()
+      Then -> @newest == @post3
 
-  #   describe "#newest", ->
-  #     When -> @newest = @subject.newest()
-  #     Then -> @newest == @post3
+    describe "#older", ->
+      When -> @older = @subject.older(@post)
 
-  #   describe "#older", ->
-  #     When -> @older = @subject.older(@post)
+      context "given the oldest post", ->
+        Given -> @post = @post1
+        Then -> @older == undefined
 
-  #     context "given the oldest post", ->
-  #       Given -> @post = @post1
-  #       Then -> @older == undefined
+      context "given a newer post", ->
+        Given -> @post = @post2
+        Then -> @older == @post1
 
-  #     context "given a newer post", ->
-  #       Given -> @post = @post2
-  #       Then -> @older == @post1
+    describe "#newer", ->
+      When -> @newer = @subject.newer(@post)
 
-  #   describe "#newer", ->
-  #     When -> @newer = @subject.newer(@post)
+      context "given the latest post", ->
+        Given -> @post = @post3
+        Then -> @newer == undefined
 
-  #     context "given the latest post", ->
-  #       Given -> @post = @post3
-  #       Then -> @newer == undefined
-
-  #     context "given an older post", ->
-  #       Given -> @post = @post2
-  #       Then -> @newer == @post3
+      context "given an older post", ->
+        Given -> @post = @post2
+        Then -> @newer == @post3

--- a/spec/posts_spec.coffee
+++ b/spec/posts_spec.coffee
@@ -1,96 +1,92 @@
 # Post = null
 # Posts = null
-# SandboxedModule = require('sandboxed-module')
 
 # beforeEach ->
-#   Posts = SandboxedModule.require '../lib/posts',
-#     requires:
-#       './post': Post = jasmine.constructSpy("Post", ["fileName"])
+#   Post  = td.constructor(['fileName'])
+#   Posts = require '../lib/posts'
 
-
-# describe "Posts", ->
+# ddescribe "Posts", ->
 #   Given -> @markdownFiles = [ "md1", "md2" ]
-#   Given -> @config = jasmine.createSpyObj 'config', ['htmlDir', 'layout', 'dateFormat', 'comparator']
+#   Given -> @config = td.object 'config', ['htmlDir', 'layout', 'dateFormat', 'comparator']
+#   When  -> @subject = new Posts(@markdownFiles, @config)
 
-#   When -> @subject = new Posts(@markdownFiles, @config)
+#   describe "has posts", ->
+#     When -> console.log(@subject)
+#     Then -> @subject.posts.length == 2
 
-#   describe "is array-like", ->
-#     Then -> @subject instanceof Posts
-#     Then -> @subject instanceof Array
-#     Then -> @subject.length == 2
+  # describe "builds posts", ->
+  #   Given -> @markdownFiles = [ @post1 = td.object('post1') ]
 
+  #   Then -> @subject.getPosts()[0] instanceof Post
+  #   Then -> td.verify(Post(@post1, @config.htmlDir, @config.dateFormat))
 
-#   describe "builds posts", ->
-#     Given -> @markdownFiles = [ @post1 = jasmine.createSpy('post1') ]
-
-#     Then -> @subject[0] instanceof Post
-#     Then -> expect(Post).toHaveBeenCalledWith(@post1, @config.htmlDir, @config.dateFormat)
-
-
-#   describe "is sorted automatically", ->
-#     Then -> expect(@config.comparator).toHaveBeenCalled()
+  # describe "is sorted automatically", ->
+  #   Then -> expect(@config.comparator).toHaveBeenCalled()
 
 
-#   describe "#htmlFor", ->
-#     Given -> @site = "site"
-#     Given -> @post = "post"
-#     Given -> @html = "html"
-#     Given -> @config.layout.htmlFor = jasmine.createSpy('layout.htmlFor').andReturn(@html)
-#     When -> @htmlFor = @subject.htmlFor(@site, @post)
-#     Then -> expect(@config.layout.htmlFor).toHaveBeenCalledWith(site: @site, post: @post)
-#     Then -> @htmlFor == @html
+  # describe "#htmlFor", ->
+  #   Given -> @site = "site"
+  #   Given -> @post = "post"
+  #   Given -> @html = "html"
+  #   Given ->
+  #     @config.layout.htmlFor = td.func('layout.htmlFor')
+  #     td.when(@config.layout.htmlFor(@site, @post).thenReturn(@html))
+  #   Then -> @subject.htmlFor(@site, @post) == @html
 
-#   describe "#writeHtml", ->
-#     Given -> @html = "html"
-#     Given -> @generatesHtml = jasmine.createStubObj('generatesHtml', generate: @html)
-#     Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
+  # describe "#writeHtml", ->
+  #   Given -> @html = "html"
+  #   Given -> @generatesHtml = td.object('generatesHtml', ['generate'])
+  #   Given -> @writesFile = td.object('writesFile', ['write'])
 
-#     context "without posts", ->
-#       Given -> @markdownFiles = []
-#       When -> @subject.writeHtml(@generatesHtml, @writesFile)
-#       Then -> expect(@generatesHtml.generate).not.toHaveBeenCalled()
-#       Then -> expect(@writesFile.write).not.toHaveBeenCalled()
+  #   context "without posts", ->
+  #     Given -> @markdownFiles = []
+  #     When -> @subject.writeHtml(@generatesHtml, @writesFile)
+  #     Then -> @generatesHtml.callCount == 0
+  #     Then -> @writesFile.callCount == 0
 
-#     context "with 3 posts", ->
-#       Given -> @htmlPath = "htmlPath"
-#       Given -> @post = jasmine.createStubObj('post', htmlPath: @htmlPath)
-#       When -> @subject.splice 0, @subject.length, @post, @post, @post
-#       When -> @subject.writeHtml(@generatesHtml, @writesFile)
-#       Then -> @generatesHtml.generate.callCount == 3
-#       Then -> expect(@generatesHtml.generate).toHaveBeenCalledWith(@config.layout, @post)
-#       Then -> @writesFile.write.callCount == 3
-#       Then -> expect(@writesFile.write).toHaveBeenCalledWith(@html, @htmlPath)
+  #   context "with 3 posts", ->
+  #     Given -> @htmlPath = "htmlPath"
+  #     Given ->
+  #       @post = td.object('post', ['htmlPath'])
+  #       td.when(@post.htmlPath()).thenReturn(@htmlPath)
+  #     Given ->
+  #       @subject.posts = [@post, @post, @post]
+  #     When -> @subject.writeHtml(@generatesHtml, @writesFile)
+  #     Then -> @generatesHtml.generate.callCount == 3
+  #     Then -> td.verify(@generatesHtml.generate(@config.layout, @post))
+  #     Then -> @writesFile.write.callCount == 3
+  #     Then -> td.verify(@writesFile.write(@html, @htmlPath))
 
-#   describe '', ->
-#     Given -> [@post1, @post2, @post3] = ["oldest", "middle", "newest"]
-#     When -> @subject.splice 0, @subject.length, @post1, @post2, @post3
+  # describe '', ->
+  #   Given -> [@post1, @post2, @post3] = ["oldest", "middle", "newest"]
+  #   When -> @subject.posts = [@post1, @post2, @post3]
 
-#     describe "#oldest", ->
-#       When -> @oldest = @subject.oldest()
-#       Then -> @oldest == @post1
+  #   describe "#oldest", ->
+  #     When -> @oldest = @subject.oldest()
+  #     Then -> @oldest == @post1
 
-#     describe "#newest", ->
-#       When -> @newest = @subject.newest()
-#       Then -> @newest == @post3
+  #   describe "#newest", ->
+  #     When -> @newest = @subject.newest()
+  #     Then -> @newest == @post3
 
-#     describe "#older", ->
-#       When -> @older = @subject.older(@post)
+  #   describe "#older", ->
+  #     When -> @older = @subject.older(@post)
 
-#       context "given the oldest post", ->
-#         Given -> @post = @post1
-#         Then -> expect(@older).toBeUndefined()
+  #     context "given the oldest post", ->
+  #       Given -> @post = @post1
+  #       Then -> @older == undefined
 
-#       context "given a newer post", ->
-#         Given -> @post = @post2
-#         Then -> @older == @post1
+  #     context "given a newer post", ->
+  #       Given -> @post = @post2
+  #       Then -> @older == @post1
 
-#     describe "#newer", ->
-#       When -> @newer = @subject.newer(@post)
+  #   describe "#newer", ->
+  #     When -> @newer = @subject.newer(@post)
 
-#       context "given the latest post", ->
-#         Given -> @post = @post3
-#         Then -> expect(@newer).toBeUndefined()
+  #     context "given the latest post", ->
+  #       Given -> @post = @post3
+  #       Then -> @newer == undefined
 
-#       context "given an older post", ->
-#         Given -> @post = @post2
-#         Then -> @newer == @post3
+  #     context "given an older post", ->
+  #       Given -> @post = @post2
+  #       Then -> @newer == @post3

--- a/spec/posts_spec.coffee
+++ b/spec/posts_spec.coffee
@@ -1,96 +1,96 @@
-Post = null
-Posts = null
-SandboxedModule = require('sandboxed-module')
+# Post = null
+# Posts = null
+# SandboxedModule = require('sandboxed-module')
 
-beforeEach ->
-  Posts = SandboxedModule.require '../lib/posts',
-    requires:
-      './post': Post = jasmine.constructSpy("Post", ["fileName"])
-
-
-describe "Posts", ->
-  Given -> @markdownFiles = [ "md1", "md2" ]
-  Given -> @config = jasmine.createSpyObj 'config', ['htmlDir', 'layout', 'dateFormat', 'comparator']
-
-  When -> @subject = new Posts(@markdownFiles, @config)
-
-  describe "is array-like", ->
-    Then -> @subject instanceof Posts
-    Then -> @subject instanceof Array
-    Then -> @subject.length == 2
+# beforeEach ->
+#   Posts = SandboxedModule.require '../lib/posts',
+#     requires:
+#       './post': Post = jasmine.constructSpy("Post", ["fileName"])
 
 
-  describe "builds posts", ->
-    Given -> @markdownFiles = [ @post1 = jasmine.createSpy('post1') ]
+# describe "Posts", ->
+#   Given -> @markdownFiles = [ "md1", "md2" ]
+#   Given -> @config = jasmine.createSpyObj 'config', ['htmlDir', 'layout', 'dateFormat', 'comparator']
 
-    Then -> @subject[0] instanceof Post
-    Then -> expect(Post).toHaveBeenCalledWith(@post1, @config.htmlDir, @config.dateFormat)
+#   When -> @subject = new Posts(@markdownFiles, @config)
+
+#   describe "is array-like", ->
+#     Then -> @subject instanceof Posts
+#     Then -> @subject instanceof Array
+#     Then -> @subject.length == 2
 
 
-  describe "is sorted automatically", ->
-    Then -> expect(@config.comparator).toHaveBeenCalled()
+#   describe "builds posts", ->
+#     Given -> @markdownFiles = [ @post1 = jasmine.createSpy('post1') ]
+
+#     Then -> @subject[0] instanceof Post
+#     Then -> expect(Post).toHaveBeenCalledWith(@post1, @config.htmlDir, @config.dateFormat)
 
 
-  describe "#htmlFor", ->
-    Given -> @site = "site"
-    Given -> @post = "post"
-    Given -> @html = "html"
-    Given -> @config.layout.htmlFor = jasmine.createSpy('layout.htmlFor').andReturn(@html)
-    When -> @htmlFor = @subject.htmlFor(@site, @post)
-    Then -> expect(@config.layout.htmlFor).toHaveBeenCalledWith(site: @site, post: @post)
-    Then -> @htmlFor == @html
+#   describe "is sorted automatically", ->
+#     Then -> expect(@config.comparator).toHaveBeenCalled()
 
-  describe "#writeHtml", ->
-    Given -> @html = "html"
-    Given -> @generatesHtml = jasmine.createStubObj('generatesHtml', generate: @html)
-    Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
 
-    context "without posts", ->
-      Given -> @markdownFiles = []
-      When -> @subject.writeHtml(@generatesHtml, @writesFile)
-      Then -> expect(@generatesHtml.generate).not.toHaveBeenCalled()
-      Then -> expect(@writesFile.write).not.toHaveBeenCalled()
+#   describe "#htmlFor", ->
+#     Given -> @site = "site"
+#     Given -> @post = "post"
+#     Given -> @html = "html"
+#     Given -> @config.layout.htmlFor = jasmine.createSpy('layout.htmlFor').andReturn(@html)
+#     When -> @htmlFor = @subject.htmlFor(@site, @post)
+#     Then -> expect(@config.layout.htmlFor).toHaveBeenCalledWith(site: @site, post: @post)
+#     Then -> @htmlFor == @html
 
-    context "with 3 posts", ->
-      Given -> @htmlPath = "htmlPath"
-      Given -> @post = jasmine.createStubObj('post', htmlPath: @htmlPath)
-      When -> @subject.splice 0, @subject.length, @post, @post, @post
-      When -> @subject.writeHtml(@generatesHtml, @writesFile)
-      Then -> @generatesHtml.generate.callCount == 3
-      Then -> expect(@generatesHtml.generate).toHaveBeenCalledWith(@config.layout, @post)
-      Then -> @writesFile.write.callCount == 3
-      Then -> expect(@writesFile.write).toHaveBeenCalledWith(@html, @htmlPath)
+#   describe "#writeHtml", ->
+#     Given -> @html = "html"
+#     Given -> @generatesHtml = jasmine.createStubObj('generatesHtml', generate: @html)
+#     Given -> @writesFile = jasmine.createSpyObj('writesFile', ['write'])
 
-  describe '', ->
-    Given -> [@post1, @post2, @post3] = ["oldest", "middle", "newest"]
-    When -> @subject.splice 0, @subject.length, @post1, @post2, @post3
+#     context "without posts", ->
+#       Given -> @markdownFiles = []
+#       When -> @subject.writeHtml(@generatesHtml, @writesFile)
+#       Then -> expect(@generatesHtml.generate).not.toHaveBeenCalled()
+#       Then -> expect(@writesFile.write).not.toHaveBeenCalled()
 
-    describe "#oldest", ->
-      When -> @oldest = @subject.oldest()
-      Then -> @oldest == @post1
+#     context "with 3 posts", ->
+#       Given -> @htmlPath = "htmlPath"
+#       Given -> @post = jasmine.createStubObj('post', htmlPath: @htmlPath)
+#       When -> @subject.splice 0, @subject.length, @post, @post, @post
+#       When -> @subject.writeHtml(@generatesHtml, @writesFile)
+#       Then -> @generatesHtml.generate.callCount == 3
+#       Then -> expect(@generatesHtml.generate).toHaveBeenCalledWith(@config.layout, @post)
+#       Then -> @writesFile.write.callCount == 3
+#       Then -> expect(@writesFile.write).toHaveBeenCalledWith(@html, @htmlPath)
 
-    describe "#newest", ->
-      When -> @newest = @subject.newest()
-      Then -> @newest == @post3
+#   describe '', ->
+#     Given -> [@post1, @post2, @post3] = ["oldest", "middle", "newest"]
+#     When -> @subject.splice 0, @subject.length, @post1, @post2, @post3
 
-    describe "#older", ->
-      When -> @older = @subject.older(@post)
+#     describe "#oldest", ->
+#       When -> @oldest = @subject.oldest()
+#       Then -> @oldest == @post1
 
-      context "given the oldest post", ->
-        Given -> @post = @post1
-        Then -> expect(@older).toBeUndefined()
+#     describe "#newest", ->
+#       When -> @newest = @subject.newest()
+#       Then -> @newest == @post3
 
-      context "given a newer post", ->
-        Given -> @post = @post2
-        Then -> @older == @post1
+#     describe "#older", ->
+#       When -> @older = @subject.older(@post)
 
-    describe "#newer", ->
-      When -> @newer = @subject.newer(@post)
+#       context "given the oldest post", ->
+#         Given -> @post = @post1
+#         Then -> expect(@older).toBeUndefined()
 
-      context "given the latest post", ->
-        Given -> @post = @post3
-        Then -> expect(@newer).toBeUndefined()
+#       context "given a newer post", ->
+#         Given -> @post = @post2
+#         Then -> @older == @post1
 
-      context "given an older post", ->
-        Given -> @post = @post2
-        Then -> @newer == @post3
+#     describe "#newer", ->
+#       When -> @newer = @subject.newer(@post)
+
+#       context "given the latest post", ->
+#         Given -> @post = @post3
+#         Then -> expect(@newer).toBeUndefined()
+
+#       context "given an older post", ->
+#         Given -> @post = @post2
+#         Then -> @newer == @post3


### PR DESCRIPTION
👋 Hey @jasonkarns and @searls, I took a stab at this today

To test, I did the following:

1. cloned https://github.com/davemo/blog.davemo.com which uses `lineman-blog`
2. symlinked global and local `lineman` to `upgrade-lineman-deps` (https://github.com/linemanjs/lineman/pull/396)
3. symlinked `lineman-blog -> grunt-markdown-blog` to my fork with these changes
4. I also ran `npm test` against these changes and made a few changes to swap `sandboxed-module` for `testdouble` (although I think there's still some gross stuff here).

There's one blocker I'm hitting that I'd love some help with if either of you have time 🤓 

The `Page` and `Post` inheritance structure was predicated on the older coffee-script syntactic sugar around ES5 constructor functions and prototype chains. I've unwound a bit of this in `5fe1edf`, but there's still something funny going on that manifests in the `archive` task:

```shell
Running "markdown:dev" (markdown) task
Pages skipped: no page sources found
Writing 10210 characters to generated/posts/2007-01-01-bundle-links.html
Writing 4730 characters to generated/posts/2008-08-18-work-bliss.html
...
Writing 5826 characters to generated/posts/2014-04-03-the-magnetic-core-philosophy.html
Writing 5826 characters to generated/index.html
Warning: app/templates/archive.pug:10
    8|         - _(site.posts).chain().clone().reverse().each(function(post){
    9|           li
  > 10|             a(href=`/${post.htmlPath()}`) #{post.title()}
    11|         - })
    12| 

post.htmlPath is not a function Used --force, continuing.
```

I'm down to pair up some time either of you are free :)