### PR TITLE
adds support for writing a jsonfeed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ markdown:
     title: "my blog"
     description: "my blog where I write things"
     url: "http://myblog.com"
-    disqus: "my_disqus_id" #<-- just remove or comment this line to disable disqus support
     rssCount: 10 #<-- remove, comment, or set to zero to disable RSS generation
     dateFormat: 'MMMM Do YYYY'
     layouts:

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -2,13 +2,16 @@ _ = require('underscore')
 
 module.exports = class Config
   @defaults:
-    author: "Full Name"
     title: "my blog"
+    url: "https://www.myblog.com"
     description: "the blog where I write things"
-    url: "http://www.myblog.com"
-    # disqus: "agile" #<-- define a disqus name for use in your templates
-    rssCount: 10
+    language: "en" # https://html.spec.whatwg.org/multipage/dom.html#attr-lang
+    image: "https://www.myblog.com/image.png"
+    favicon: "https://www.myblog.com/favicon.ico"
     dateFormat: 'MMMM Do YYYY'
+    rssCount: 10
+    author: "Full Name"
+    authorUrl: "https://twitter.com/mytwitteraccount"
     layouts:
       wrapper: "app/templates/wrapper.pug"
       index: "app/templates/index.pug"
@@ -21,6 +24,7 @@ module.exports = class Config
       index: "index.html"
       archive: "archive.html"
       rss: "index.xml"
+      json: "index.json"
     pathRoots:
       posts: "posts"
       pages: "pages"
@@ -39,8 +43,9 @@ module.exports = class Config
     htmlPath: @raw.paths.archive
     layoutPath: @raw.layouts.archive
 
-  forFeed: ->
+  forFeeds: ->
     rssPath: @raw.paths.rss
+    jsonPath: @raw.paths.json
     postCount: @raw.rssCount
 
   forIndex: ->

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -1,4 +1,4 @@
-module.exports = (grunt, { Archive, Feed, Index, Layout, NullFeed, NullHtml, Pages, Posts }) ->
+module.exports = (grunt, { Archive, Feeds, Index, Layout, NullFeed, NullHtml, Pages, Posts }) ->
   archiveFrom: ({htmlPath, layoutPath}) ->
     unless htmlPath?
       grunt.log.writeln "Archive skipped: destination path undefined"
@@ -14,11 +14,14 @@ module.exports = (grunt, { Archive, Feed, Index, Layout, NullFeed, NullHtml, Pag
         htmlPath: htmlPath
         layout: new Layout(layoutPath)
 
-  feedFrom: ({rssPath, postCount}) ->
-    if rssPath? and postCount
-      new Feed arguments...
+  feedsFrom: ({rssPath, jsonPath, postCount}) ->
+    if rssPath? and jsonPath? and postCount
+      new Feeds arguments...
     else unless rssPath?
       grunt.log.writeln "RSS Feed skipped: destination path undefined"
+      new NullFeed
+    else unless jsonPath?
+      grunt.log.writeln "JSON Feed skipped: destination path undefined"
       new NullFeed
     else unless postCount
       grunt.log.writeln "RSS Feed skipped: 0 posts"

--- a/lib/feed.coffee
+++ b/lib/feed.coffee
@@ -1,5 +1,0 @@
-module.exports = class Feed
-  constructor: ({@rssPath, @postCount}) ->
-
-  writeRss: (generatesRss, writesFile) ->
-    writesFile.write generatesRss.generate(), @rssPath

--- a/lib/feeds.coffee
+++ b/lib/feeds.coffee
@@ -1,0 +1,8 @@
+module.exports = class Feeds
+  constructor: ({@rssPath, @jsonPath, @postCount}) ->
+
+  writeFeeds: (generatesRss, writesFile) ->
+    feeds = generatesRss.generate()
+    writesFile.write feeds.rss, @rssPath
+    writesFile.write feeds.json, @jsonPath
+

--- a/lib/generates_rss.coffee
+++ b/lib/generates_rss.coffee
@@ -1,24 +1,36 @@
 module.exports = class GeneratesRss
-  constructor: (@site, @Rss = require('rss')) ->
+  constructor: (@site, @FeedGenerator = require('feed').Feed) ->
 
   generate: ->
     feed = @createFeed()
     @addPostsTo(feed)
-    feed.xml()
+    return
+      rss: feed.rss2()
+      json: feed.json1()
 
   createFeed: ->
-    new @Rss
+    new @FeedGenerator
       title: @site.title
+      link: @site.url
       description: @site.description
-      feed_url: "#{@site.url}/#{@site.paths.rss}"
-      site_url: @site.url
-      author: @site.author
+      language: "#{@site.language}"
+      image: "#{@site.image}"
+      favicon: "#{@site.favicon}"
+      copyright: "Copyright © #{new Date().getFullYear()}, #{@site.author}"
+      feedLinks:
+        rss: "#{@site.url}/#{@site.paths.rss}"
+        json: "#{@site.url}/#{@site.paths.json}"
+      author:
+        name: @site.author
+        link: @site.authorUrl
 
   addPostsTo: (feed) ->
     if @site.rssCount > 0
       @site.getPosts().slice(-@site.rssCount).reverse().forEach (post) =>
-        feed.item
+        feed.addItem
           title: post.title()
-          description: post.content()
+          id: @site.urlFor(post)
           url: @site.urlFor(post)
-          date: post.time()
+          description: post.description()
+          content: post.content()
+          date: new Date(post.time())

--- a/lib/markdown_task.coffee
+++ b/lib/markdown_task.coffee
@@ -5,7 +5,7 @@ Site = require('../lib/site')
 WritesFile = require('../lib/writes_file')
 
 Archive  = require('../lib/archive')
-Feed     = require('../lib/feed')
+Feeds    = require('../lib/feeds')
 Index    = require('../lib/index')
 Layout   = require('../lib/layout')
 NullFeed = require('../lib/null_feed')
@@ -15,12 +15,12 @@ Posts    = require('../lib/posts')
 
 module.exports = class MarkdownTask
   constructor: (grunt, @config) ->
-    factory = Factory(grunt, { Archive, Feed, Index, Layout, NullFeed, NullHtml, Pages, Posts })
+    factory = Factory(grunt, { Archive, Feeds, Index, Layout, NullFeed, NullHtml, Pages, Posts })
     @posts = factory.postsFrom @config.forPosts()
     @pages = factory.pagesFrom @config.forPages()
     @index = factory.indexFrom @posts.newest(), @config.forIndex()
     @archive = factory.archiveFrom @config.forArchive()
-    @feed = factory.feedFrom @config.forFeed()
+    @feeds = factory.feedsFrom @config.forFeeds()
     @wrapper = factory.siteWrapperFrom @config.forSiteWrapper()
     @site = new Site(@config.raw, @posts, @pages)
 
@@ -33,4 +33,4 @@ module.exports = class MarkdownTask
     @index.writeHtml generatesHtml, writesFile
     @archive.writeHtml generatesHtml, writesFile
 
-    @feed.writeRss new GeneratesRss(@site), writesFile
+    @feeds.writeFeeds new GeneratesRss(@site), writesFile

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -8,6 +8,9 @@ module.exports = class Page
     @markdown = new Markdown(@reader.read(@path))
     @attributes = @markdown.header
 
+  description: ->
+    @get('description')
+
   content: ->
     @markdown.compile()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,16 +6,16 @@
   "packages": {
     "": {
       "name": "grunt-markdown-blog",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "coffeescript": "^2.5.1",
+        "feed": "^4.2.2",
         "grunt": "^1.4.0",
         "highlight.js": "^11.3.1",
         "marked": "^4.0.3",
         "moment": "~2.19.3",
         "pug": "^3.0.2",
-        "rss": "^1.2.2",
         "underscore": "~1.12.1",
         "underscore.string": "~3.3.5"
       },
@@ -300,6 +300,17 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -1072,25 +1083,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-      "dependencies": {
-        "mime-db": "~1.25.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minijasminenode": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-0.2.7.tgz",
@@ -1472,19 +1464,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rss": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
-      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
-      "dependencies": {
-        "mime-types": "2.1.13",
-        "xml": "1.0.1"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -1648,10 +1636,16 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
     }
   },
   "dependencies": {
@@ -1860,6 +1854,14 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "requires": {
+        "xml-js": "^1.6.11"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -2452,19 +2454,6 @@
         "picomatch": "^2.2.3"
       }
     },
-    "mime-db": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
-    },
-    "mime-types": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-      "requires": {
-        "mime-db": "~1.25.0"
-      }
-    },
     "minijasminenode": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-0.2.7.tgz",
@@ -2772,19 +2761,15 @@
         "glob": "^7.1.3"
       }
     },
-    "rss": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
-      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
-      "requires": {
-        "mime-types": "2.1.13",
-        "xml": "1.0.1"
-      }
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -2914,10 +2899,13 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "dependencies": {
     "coffeescript": "^2.5.1",
+    "feed": "^4.2.2",
     "grunt": "^1.4.0",
     "highlight.js": "^11.3.1",
     "marked": "^4.0.3",
     "moment": "~2.19.3",
     "pug": "^3.0.2",
-    "rss": "^1.2.2",
     "underscore": "~1.12.1",
     "underscore.string": "~3.3.5"
   },


### PR DESCRIPTION
- the feed library currently only writes jsonfeed 1, and 1.1 is the latest :(
- nested config overrides upstream from [yourblog]->lineman-blog->grunt-markdown-blog is painful
- perhaps there is another jsonfeed writer that supports 1.1
- having to recast the post.time() as a new Date(post.time()) feels clunky, but feed seems to want to invoke .toUTCString on it for some reason